### PR TITLE
refactor(swagger): deduplicate V2/V3 generator logic into abstract base

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -66,7 +66,15 @@ SwaggerGenerator (abstract.ts)
 └── V3Generator   — OpenAPI 3.0 output
 ```
 
-The abstract generator handles shared logic (schema building, reference resolution, model definitions). Version-specific generators handle format differences (e.g., `requestBody` in v3 vs. `in: body` parameters in v2).
+The abstract generator handles shared logic: schema building, reference resolution, model definitions, property building, enum schemas, and ref alias/object schemas. Version-specific differences are handled via abstract hooks:
+
+- `getRefPrefix()` — `#/definitions/` (V2) vs `#/components/schemas/` (V3)
+- `applyNullable()` — `x-nullable` (V2) vs `nullable` (V3)
+- `markPropertyDeprecated()` — `x-deprecated` (V2) vs `deprecated` (V3)
+- `assignPropertyDefaults()` — no-op (V2) vs sets `default` (V3)
+- `resolveAdditionalProperties()` — `true` (V2) vs resolved type schema (V3)
+
+Version-specific generators handle structural format differences (e.g., `requestBody` in V3 vs `in: body` parameters in V2, `allOf` composition in V3 vs flattened properties in V2).
 
 ## Caching
 

--- a/.agents/references/openapi-specification.md
+++ b/.agents/references/openapi-specification.md
@@ -6,6 +6,9 @@ The official JSON Schema files for validating OpenAPI documents live in the OAI 
 
 - **Repository**: https://github.com/OAI/OpenAPI-Specification
 - **Schema directory**: `_archive_/schemas/`
+- **Version snapshot**: Based on OAI/OpenAPI-Specification as of 2026-04-10
+
+These schemas can be used to validate generated OpenAPI documents and to extend our test suites for V2 and V3 compliance.
 
 ### V2 (Swagger)
 
@@ -19,6 +22,7 @@ Key structural rules:
 - Security definitions: `basic`, `apiKey`, `oauth2` (implicit, password, application, accessCode flows)
 - `additionalProperties` is boolean only (no typed schema)
 - No `requestBody` — file uploads via `in: formData` with `consumes: ["multipart/form-data"]`
+- `deprecated` not available on properties — use `x-deprecated` extension
 
 ### V3.0
 
@@ -30,10 +34,11 @@ Key structural rules:
 - `nullable: true` alongside `type` for nullable types
 - `requestBody` replaces `in: body` parameters
 - File uploads via `requestBody` with `multipart/form-data` content type
-- Security schemes: `http`, `apiKey`, `oauth2`, `openIdConnect`
+- Security schemes: `http` (with `scheme` field, not `schema`), `apiKey`, `oauth2`, `openIdConnect`
 - `additionalProperties` can be boolean or Schema Object
 - `allOf` / `oneOf` / `anyOf` for composition
 - `discriminator` with `propertyName` for polymorphic types
+- `deprecated: true` natively supported on properties, operations, parameters
 
 ### V3.1
 
@@ -50,18 +55,30 @@ Key differences from 3.0:
 
 ## TRAPI Mapping
 
-| OpenAPI Concept | TRAPI V2 Generator | TRAPI V3 Generator |
-|----------------|--------------------|--------------------|
-| `$ref` isolation | `buildProperties` early return | `buildProperties` early return |
-| Nullable types | `x-nullable: true` | `nullable: true` |
-| File upload | `in: formData, type: file` | `requestBody` + `multipart/form-data` |
-| Security | `securityDefinitions` | `components.securitySchemes` |
-| Composition | N/A (flattened) | `allOf` / `oneOf` |
-| Additional props | `additionalProperties: true` | `additionalProperties: { type }` |
-| Enums | `enum` array | `enum` array (mixed → `anyOf`) |
+| OpenAPI Concept | TRAPI Abstract Base | TRAPI V2 Override | TRAPI V3 Override |
+|----------------|--------------------|--------------------|-------------------|
+| `$ref` prefix | `getRefPrefix()` | `#/definitions/` | `#/components/schemas/` |
+| `$ref` isolation | `buildProperties` early return | — | — |
+| Nullable | `applyNullable()` | `x-nullable` | `nullable` |
+| Deprecated props | `markPropertyDeprecated()` | `x-deprecated` | `deprecated` |
+| Property defaults | `assignPropertyDefaults()` | no-op | sets `default` |
+| Additional props | `resolveAdditionalProperties()` | `true` (boolean) | resolves type schema |
+| File upload | — | `in: formData, type: file` | `requestBody` + `multipart/form-data` |
+| Security | — | `securityDefinitions` | `components.securitySchemes` |
+| Composition | — | flattened (no `allOf`) | `allOf` / `oneOf` |
+| Enums (single-type) | `buildSchemaForRefEnum` | — | — |
+| Enums (multi-type) | — | falls back to `string` | `anyOf` with per-type sub-schemas |
+
+## Test Validation Strategy
+
+Use the OAI JSON Schemas to validate generated specs against the official standard:
+- V2 output → validate against `_archive_/schemas/v2.0/schema.json`
+- V3 output → validate against `_archive_/schemas/v3.0/schema.json` (or `v3.1/schema.json` once 3.1 is properly targeted)
+
+This allows us to catch spec violations that unit tests might miss (e.g., invalid property combinations, wrong types).
 
 ## Known Gaps
 
-- TRAPI outputs `openapi: '3.1.0'` but uses 3.0.x patterns (no type arrays, no `$ref` siblings)
+- TRAPI outputs `openapi: '3.1.0'` but uses 3.0.x patterns (no type arrays, no `$ref` siblings) — tracked in Plan #012 gap #3
 - No `discriminator` support yet (planned in Plan #005)
-- V2 `additionalProperties: true` loses type information (design choice)
+- V2 `additionalProperties: true` loses type information (design choice, documented in `resolveAdditionalProperties`)

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -48,6 +48,7 @@ import { SwaggerError, SwaggerErrorCode } from '../error';
 import type { Options, OptionsInput } from '../config';
 import type { DocumentFormat } from '../constants';
 import { DataFormatName, DataTypeName } from '../schema';
+import { transformValueTo } from '../utils';
 
 import type { DocumentFormatData } from '../types';
 import type {
@@ -164,7 +165,21 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
 
     protected abstract getSchemaForIntersectionType(type: IntersectionType): Schema;
 
-    protected abstract getSchemaForEnumType(enumType: EnumType): Schema;
+    protected getSchemaForEnumType(enumType: EnumType): Schema {
+        const type = this.decideEnumType(enumType.members);
+        const nullable = !!enumType.members.includes(null);
+
+        const schema = {
+            type,
+            enum: enumType.members.map((member) => transformValueTo(type, member)),
+        } as Schema;
+
+        this.applyNullable(schema, nullable);
+
+        return schema;
+    }
+
+    protected abstract applyNullable(schema: Schema, nullable: boolean): void;
 
     private getSchemaForPrimitiveType(type: PrimitiveType): BaseSchema<Schema> {
         const PrimitiveSwaggerTypeMap: Partial<Record<TypeName, BaseSchema<Schema>>> = {
@@ -219,17 +234,46 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
         } as BaseSchema<Schema>;
     }
 
-    protected abstract getSchemaForReferenceType(referenceType: ReferenceType): Schema;
+    protected getSchemaForReferenceType(referenceType: ReferenceType): Schema {
+        return { $ref: `${this.getRefPrefix()}${referenceType.refName}` } as Schema;
+    }
+
+    protected abstract getRefPrefix(): string;
 
     protected abstract getSchemaForUnionType(type: UnionType) : Schema;
 
     // ----------------------------------------------------------------
 
-    protected abstract buildSchemaForRefAlias(referenceType: RefAliasType) : Schema;
+    protected buildSchemaForRefAlias(referenceType: RefAliasType): Schema {
+        const swaggerType = this.getSchemaForType(referenceType.type);
+        const format = referenceType.format as DataFormatName;
 
-    protected abstract buildSchemaForRefEnum(referenceType: RefEnumType) : Schema;
+        return {
+            ...(swaggerType as Schema),
+            default: referenceType.default || swaggerType.default,
+            example: referenceType.example,
+            format: format || swaggerType.format,
+            description: referenceType.description,
+            ...this.transformValidators(referenceType.validators),
+        };
+    }
 
-    protected abstract buildSchemaForRefObject(referenceType: RefObjectType) : Schema;
+    protected buildSchemaForRefEnum(referenceType: RefEnumType): Schema {
+        const output = {
+            description: referenceType.description,
+            enum: referenceType.members,
+            type: this.decideEnumType(referenceType.members),
+        } as unknown as Schema;
+
+        if (
+            typeof referenceType.memberNames !== 'undefined' &&
+            referenceType.members.length === referenceType.memberNames.length
+        ) {
+            (output as any)['x-enum-varnames'] = referenceType.memberNames;
+        }
+
+        return output;
+    }
 
     protected buildSchemasForReferenceTypes(extendFn?: (output: Schema, input: ReferenceType) => void) : Record<string, Schema> {
         const output: Record<string, Schema> = {};
@@ -268,7 +312,69 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
             (isUnionType(input.type) && input.type.members.some((el) => isUndefinedType(el)));
     }
 
-    protected abstract buildProperties(properties: ResolverProperty[]): Record<string, Schema>;
+    protected buildProperties(properties: ResolverProperty[]): Record<string, Schema> {
+        const output: Record<string, Schema> = {};
+
+        properties.forEach((property) => {
+            const swaggerType = this.getSchemaForType(property.type) as Schema;
+
+            if (swaggerType.$ref) {
+                output[property.name] = { $ref: swaggerType.$ref } as Schema;
+                return;
+            }
+
+            swaggerType.description = property.description;
+            swaggerType.example = property.example;
+            swaggerType.format = property.format as DataFormatName || swaggerType.format;
+            this.assignPropertyDefaults(swaggerType, property);
+
+            if (property.deprecated) {
+                this.markPropertyDeprecated(swaggerType);
+            }
+
+            const extensions = this.transformExtensions(property.extensions);
+            const validators = this.transformValidators(property.validators);
+            output[property.name] = {
+                ...swaggerType,
+                ...validators,
+                ...extensions,
+            };
+        });
+
+        return output;
+    }
+
+    protected abstract markPropertyDeprecated(schema: Schema): void;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    protected assignPropertyDefaults(schema: Schema, property: ResolverProperty): void {
+        // No-op by default. V3 overrides to set schema.default = property.default.
+    }
+
+    protected buildSchemaForRefObject(referenceType: RefObjectType): Schema {
+        const required = referenceType.properties
+            .filter((p) => p.required && !this.isUndefinedProperty(p))
+            .map((p) => p.name);
+
+        const output = {
+            description: referenceType.description,
+            properties: this.buildProperties(referenceType.properties),
+            required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
+            type: DataTypeName.OBJECT,
+        } as unknown as Schema;
+
+        if (referenceType.additionalProperties) {
+            (output as any).additionalProperties = this.resolveAdditionalProperties(referenceType.additionalProperties);
+        }
+
+        if (referenceType.example) {
+            output.example = referenceType.example;
+        }
+
+        return output;
+    }
+
+    protected abstract resolveAdditionalProperties(type: BaseType): Schema | boolean;
 
     protected determineTypesUsedInEnum(anEnum: Array<string | number | boolean | null>) : VariableType[] {
         const set = new Set<VariableType>();

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -250,10 +250,10 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
 
         return {
             ...(swaggerType as Schema),
-            default: referenceType.default || swaggerType.default,
-            example: referenceType.example,
-            format: format || swaggerType.format,
-            description: referenceType.description,
+            default: referenceType.default ?? swaggerType.default,
+            example: referenceType.example ?? swaggerType.example,
+            format: format ?? swaggerType.format,
+            description: referenceType.description ?? swaggerType.description,
             ...this.transformValidators(referenceType.validators),
         };
     }

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -260,10 +260,12 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
 
     protected buildSchemaForRefEnum(referenceType: RefEnumType): Schema {
         const output = {
+            ...this.getSchemaForEnumType({
+                typeName: TypeName.ENUM,
+                members: referenceType.members,
+            }),
             description: referenceType.description,
-            enum: referenceType.members,
-            type: this.decideEnumType(referenceType.members),
-        } as unknown as Schema;
+        } as Schema;
 
         if (
             typeof referenceType.memberNames !== 'undefined' &&

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -369,7 +369,7 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
             (output as any).additionalProperties = this.resolveAdditionalProperties(referenceType.additionalProperties);
         }
 
-        if (referenceType.example) {
+        if (referenceType.example !== undefined) {
             output.example = referenceType.example;
         }
 

--- a/packages/swagger/src/generator/v2/module.ts
+++ b/packages/swagger/src/generator/v2/module.ts
@@ -6,15 +6,12 @@
  */
 
 import type {
+    BaseType,
     EnumType,
     IntersectionType,
     Method,
     Parameter,
-    RefAliasType,
-    RefEnumType,
     RefObjectType,
-    ReferenceType,
-    ResolverProperty,
     Response,
     Type,
     UnionType,
@@ -36,8 +33,6 @@ import { merge } from 'smob';
 
 import type {
     BaseSchema,
-    DataFormatName,
-    Example,
     OperationV2,
     ParameterV2,
     Path,
@@ -49,7 +44,7 @@ import type {
 import { DataTypeName, ParameterSourceV2 } from '../../schema';
 import type { SecurityDefinitions } from '../../types';
 import { SwaggerError, SwaggerErrorCode } from '../../error';
-import { normalizePathParameters, transformValueTo } from '../../utils';
+import { normalizePathParameters } from '../../utils';
 import { AbstractSpecGenerator } from '../abstract';
 
 export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
@@ -161,56 +156,15 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
         return definitions;
     }
 
-    protected buildSchemaForRefObject(referenceType: RefObjectType) : SchemaV2 {
-        const required = referenceType.properties
-            .filter((p: ResolverProperty) => p.required && !this.isUndefinedProperty(p))
-            .map((p: ResolverProperty) => p.name);
-
-        const output : SchemaV2 = {
-            description: referenceType.description,
-            properties: this.buildProperties(referenceType.properties),
-            required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
-            type: DataTypeName.OBJECT,
-        };
-
-        if (referenceType.additionalProperties) {
-            output.additionalProperties = true;
-        }
-
-        if (referenceType.example) {
-            output.example = referenceType.example;
-        }
-
-        return output;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    protected resolveAdditionalProperties(type: BaseType): SchemaV2 | boolean {
+        return true;
     }
 
-    protected buildSchemaForRefEnum(referenceType: RefEnumType) : SchemaV2 {
-        const output : SchemaV2 = {
-            description: referenceType.description,
-            enum: referenceType.members,
-            type: this.decideEnumType(referenceType.members),
-        };
-
-        if (referenceType.memberNames !== undefined && referenceType.members.length === referenceType.memberNames.length) {
-            output['x-enum-varnames'] = referenceType.memberNames;
-        }
-
-        return output;
+    protected markPropertyDeprecated(schema: SchemaV2): void {
+        schema['x-deprecated'] = true;
     }
 
-    protected buildSchemaForRefAlias(referenceType: RefAliasType) : SchemaV2 {
-        const swaggerType = this.getSchemaForType(referenceType.type);
-        const format = referenceType.format as DataFormatName;
-
-        return {
-            ...(swaggerType as SchemaV2),
-            default: referenceType.default || swaggerType.default,
-            example: referenceType.example as { [p: string]: Example },
-            format: format || swaggerType.format,
-            description: referenceType.description,
-            ...this.transformValidators(referenceType.validators),
-        };
-    }
 
     /*
         Path & Parameter ( + utils)
@@ -509,15 +463,12 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
         Swagger Type ( + utils)
      */
 
-    protected getSchemaForEnumType(enumType: EnumType) : SchemaV2 {
-        const type = this.decideEnumType(enumType.members);
-        const nullable = !!enumType.members.includes(null);
+    protected applyNullable(schema: SchemaV2, nullable: boolean): void {
+        schema['x-nullable'] = nullable;
+    }
 
-        return {
-            type,
-            enum: enumType.members.map((member) => transformValueTo(type, member)),
-            'x-nullable': nullable,
-        };
+    protected getRefPrefix(): string {
+        return '#/definitions/';
     }
 
     protected getSchemaForIntersectionType(type: IntersectionType) : SchemaV2 {
@@ -540,9 +491,6 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
         return { type: DataTypeName.OBJECT, properties };
     }
 
-    protected getSchemaForReferenceType(referenceType: ReferenceType): SchemaV2 {
-        return { $ref: `#/definitions/${referenceType.refName}` };
-    }
 
     protected getSchemaForUnionType(type: UnionType) : SchemaV2 {
         const members : Type[] = [];
@@ -588,37 +536,6 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
         }
 
         return { type: DataTypeName.OBJECT, ...(isNullEnum ? { 'x-nullable': true } : {}) };
-    }
-
-    protected buildProperties(properties: ResolverProperty[]) : Record<string, SchemaV2> {
-        const output: Record<string, SchemaV2> = {};
-
-        properties.forEach((property) => {
-            const swaggerType = this.getSchemaForType(property.type);
-
-            if (swaggerType.$ref) {
-                output[property.name] = { $ref: swaggerType.$ref };
-                return;
-            }
-
-            swaggerType.description = property.description;
-            swaggerType.example = property.example;
-            swaggerType.format = property.format as DataFormatName || swaggerType.format;
-
-            if (property.deprecated) {
-                swaggerType['x-deprecated'] = true;
-            }
-
-            const extensions = this.transformExtensions(property.extensions);
-            const validators = this.transformValidators(property.validators);
-            output[property.name] = {
-                ...swaggerType,
-                ...validators,
-                ...extensions,
-            };
-        });
-
-        return output;
     }
 
     private buildOperation(method: Method) {

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -6,14 +6,12 @@
  */
 
 import type {
+    BaseType,
     EnumType,
     IntersectionType,
     Method,
     Parameter,
-    RefAliasType,
     RefEnumType,
-    RefObjectType,
-    ReferenceType,
     ResolverProperty,
     Response,
     Type,
@@ -32,7 +30,6 @@ import {
 import { URL } from 'node:url';
 import { merge } from 'smob';
 import type {
-    DataFormatName,
     Example,
     HeaderV3,
     MediaTypeV3,
@@ -54,9 +51,8 @@ import type { SecurityDefinition, SecurityDefinitions } from '../../types';
 import { SwaggerError, SwaggerErrorCode } from '../../error';
 import {
     normalizePathParameters,
-    removeDuplicateSlashes, 
-    removeFinalCharacter, 
-    transformValueTo,
+    removeDuplicateSlashes,
+    removeFinalCharacter,
 } from '../../utils';
 import { AbstractSpecGenerator } from '../abstract';
 
@@ -473,51 +469,28 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         return servers;
     }
 
-    protected buildSchemaForRefObject(input: RefObjectType) : SchemaV3 {
-        const required = input.properties
-            .filter((p) => p.required && !this.isUndefinedProperty(p))
-            .map((p) => p.name);
-
-        const schema : SchemaV3 = {
-            description: input.description,
-            properties: this.buildProperties(input.properties),
-            required: required && required.length > 0 ? Array.from(new Set(required)) : undefined,
-            type: 'object',
-        };
-
-        if (input.additionalProperties) {
-            schema.additionalProperties = this.getSchemaForType(input.additionalProperties);
-        }
-
-        if (input.example) {
-            schema.example = input.example;
-        }
-
-        return schema;
+    protected resolveAdditionalProperties(type: BaseType): SchemaV3 {
+        return this.getSchemaForType(type) as SchemaV3;
     }
 
-    protected buildSchemaForRefEnum(referenceType: RefEnumType) : SchemaV3 {
-        const type = this.decideEnumType(referenceType.members);
+    protected markPropertyDeprecated(schema: SchemaV3): void {
+        schema.deprecated = true;
+    }
+
+    protected override assignPropertyDefaults(schema: SchemaV3, property: ResolverProperty): void {
+        schema.default = property.default;
+    }
+
+    protected override buildSchemaForRefEnum(referenceType: RefEnumType): SchemaV3 {
         const typesUsed = this.determineTypesUsedInEnum(referenceType.members);
 
+        // Single-type enums use the shared base implementation
         if (typesUsed.length === 1) {
-            const schema: SchemaV3 = {
-                description: referenceType.description,
-                enum: referenceType.members,
-                type,
-            };
-
-            if (
-                typeof referenceType.memberNames !== 'undefined' &&
-                referenceType.members.length === referenceType.memberNames.length
-            ) {
-                schema['x-enum-varnames'] = referenceType.memberNames;
-            }
-
-            return schema;
+            return super.buildSchemaForRefEnum(referenceType) as SchemaV3;
         }
 
-        const schema : SchemaV3 = {
+        // Multi-type enums use anyOf with per-type sub-schemas (V3 only)
+        const schema: SchemaV3 = {
             description: referenceType.description,
             anyOf: [],
         };
@@ -525,7 +498,6 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         for (const element of typesUsed) {
             schema.anyOf.push({
                 type: element as `${DataTypeName}`,
-                 
                 enum: referenceType.members.filter((e) => typeof e === element),
             });
         }
@@ -533,69 +505,16 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         return schema;
     }
 
-    protected buildSchemaForRefAlias(referenceType: RefAliasType) : SchemaV3 {
-        const swaggerType = this.getSchemaForType(referenceType.type);
-        const format = referenceType.format as DataFormatName;
-
-        return {
-            ...(swaggerType as SchemaV3),
-            default: referenceType.default || swaggerType.default,
-            example: referenceType.example,
-            format: format || swaggerType.format,
-            description: referenceType.description,
-            ...this.transformValidators(referenceType.validators),
-        };
-    }
-
-    protected buildProperties(properties: ResolverProperty[]): Record<string, SchemaV3> {
-        const output: Record<string, SchemaV3> = {};
-
-        properties.forEach((property) => {
-            const swaggerType = this.getSchemaForType(property.type) as SchemaV3;
-
-            if (swaggerType.$ref) {
-                output[property.name] = { $ref: swaggerType.$ref };
-                return;
-            }
-
-            swaggerType.description = property.description;
-            swaggerType.example = property.example;
-            swaggerType.format = property.format as DataFormatName || swaggerType.format;
-            swaggerType.default = property.default;
-
-            if (property.deprecated) {
-                swaggerType.deprecated = true;
-            }
-
-            const extensions = this.transformExtensions(property.extensions);
-            const validators = this.transformValidators(property.validators);
-            output[property.name] = {
-                ...swaggerType,
-                ...validators,
-                ...extensions,
-            };
-        });
-
-        return output;
-    }
-
     protected getSchemaForIntersectionType(type: IntersectionType) : SchemaV3 {
         return { allOf: type.members.map((x: Type) => this.getSchemaForType(x)) };
     }
 
-    protected getSchemaForEnumType(enumType: EnumType): SchemaV3 {
-        const type = this.decideEnumType(enumType.members);
-        const nullable = !!enumType.members.includes(null);
-
-        return {
-            type,
-            enum: enumType.members.map((member) => transformValueTo(type, member)),
-            nullable,
-        };
+    protected applyNullable(schema: SchemaV3, nullable: boolean): void {
+        schema.nullable = nullable;
     }
 
-    protected getSchemaForReferenceType(referenceType: ReferenceType): SchemaV3 {
-        return { $ref: `#/components/schemas/${referenceType.refName}` };
+    protected getRefPrefix(): string {
+        return '#/components/schemas/';
     }
 
     protected getSchemaForUnionType(type: UnionType) : SchemaV3 {


### PR DESCRIPTION
closes #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture and OpenAPI reference docs with V2/V3 mapping, validation guidance, test-validation pointers, and known-gaps tracking.

* **Refactor**
  * Consolidated schema-generation behavior into a shared base with clearer version-specific differences.
  * Clarified V2 vs V3 output differences for refs, nullable handling, deprecation, defaults, additionalProperties, enum mapping/composition, and file-upload/security semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->