### PR TITLE
feat(swagger): schema validation & multi-version OpenAPI support (V2, V3.0, V3.1, V3.2)

### DIFF
--- a/.agents/references/openapi-specification.md
+++ b/.agents/references/openapi-specification.md
@@ -53,32 +53,38 @@ Key differences from 3.0:
 - `contentMediaType` / `contentEncoding` for binary content
 - `webhooks` top-level field
 
+### V3.2
+
+- Spec document: `versions/3.2.0.md` (https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md)
+
+Key differences from 3.1:
+- Incremental update building on 3.1 JSON Schema alignment
+- TRAPI does not target 3.2 yet
+
 ## TRAPI Mapping
 
-| OpenAPI Concept | TRAPI Abstract Base | TRAPI V2 Override | TRAPI V3 Override |
-|----------------|--------------------|--------------------|-------------------|
-| `$ref` prefix | `getRefPrefix()` | `#/definitions/` | `#/components/schemas/` |
-| `$ref` isolation | `buildProperties` early return | — | — |
-| Nullable | `applyNullable()` | `x-nullable` | `nullable` |
-| Deprecated props | `markPropertyDeprecated()` | `x-deprecated` | `deprecated` |
-| Property defaults | `assignPropertyDefaults()` | no-op | sets `default` |
-| Additional props | `resolveAdditionalProperties()` | `true` (boolean) | resolves type schema |
-| File upload | — | `in: formData, type: file` | `requestBody` + `multipart/form-data` |
-| Security | — | `securityDefinitions` | `components.securitySchemes` |
-| Composition | — | flattened (no `allOf`) | `allOf` / `oneOf` |
-| Enums (single-type) | `buildSchemaForRefEnum` | — | — |
-| Enums (multi-type) | — | falls back to `string` | `anyOf` with per-type sub-schemas |
+| OpenAPI Concept | TRAPI V2 Generator | TRAPI V3 Generator |
+|----------------|--------------------|--------------------|
+| `$ref` prefix | `#/definitions/` | `#/components/schemas/` |
+| `$ref` isolation | `buildProperties` early return | `buildProperties` early return |
+| Nullable types | `x-nullable: true` | `nullable: true` |
+| Deprecated props | `x-deprecated: true` | `deprecated: true` |
+| Additional props | `additionalProperties: true` | `additionalProperties: { type }` |
+| File upload | `in: formData, type: file` | `requestBody` + `multipart/form-data` |
+| Security | `securityDefinitions` | `components.securitySchemes` |
+| Composition | flattened (no `allOf`) | `allOf` / `oneOf` |
+| Enums (single-type) | `enum` array | `enum` array |
+| Enums (multi-type) | falls back to `string` | `anyOf` with per-type sub-schemas |
 
-## Test Validation Strategy
+## Test Validation
 
-Use the OAI JSON Schemas to validate generated specs against the official standard:
-- V2 output → validate against `_archive_/schemas/v2.0/schema.json`
-- V3 output → validate against `_archive_/schemas/v3.0/schema.json` (or `v3.1/schema.json` once 3.1 is properly targeted)
+Vendored OAI JSON Schemas in `packages/swagger/test/schemas/`:
+- `v2.0-schema.json` — validates V2 output against the official Swagger 2.0 schema
+- `v3.0-schema.json` — validates V3 output against the official OpenAPI 3.0 schema
 
-This allows us to catch spec violations that unit tests might miss (e.g., invalid property combinations, wrong types).
+The `schema-validator.ts` helper uses `ajv-draft-04` (both schemas use JSON Schema draft-04).
 
 ## Known Gaps
 
-- TRAPI outputs `openapi: '3.1.0'` but uses 3.0.x patterns (no type arrays, no `$ref` siblings) — tracked in Plan #012 gap #3
 - No `discriminator` support yet (planned in Plan #005)
-- V2 `additionalProperties: true` loses type information (design choice, documented in `resolveAdditionalProperties`)
+- V2 `additionalProperties: true` loses type information (design choice)

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -62,7 +62,11 @@ packages/metadata/test/
 packages/swagger/test/
 ├── vitest.config.ts
 ├── helpers/
-│   └── metadata-builder.ts  # Typed factory functions for inline metadata fixtures
+│   ├── metadata-builder.ts  # Typed factory functions for inline metadata fixtures
+│   └── schema-validator.ts  # OAI JSON Schema validation (ajv-draft-04)
+├── schemas/
+│   ├── v2.0-schema.json     # Official OAI Swagger 2.0 JSON Schema
+│   └── v3.0-schema.json     # Official OAI OpenAPI 3.0 JSON Schema
 ├── unit/
 │   ├── specification/  # Endpoint specification tests
 │   └── utils/
@@ -93,3 +97,5 @@ The following test files use inline metadata to verify OpenAPI compliance:
 | `additional-properties.spec.ts` | V2 boolean vs V3 typed schema |
 | `edge-cases.spec.ts` | Empty required arrays, void responses, spec structure |
 | `error-paths.spec.ts` | Duplicate body params, body+form conflict, cookie filtering, hidden methods |
+| `schema-validation.spec.ts` | V2/V3 output validated against official OAI JSON Schemas |
+| `config-variations.spec.ts` | specificationExtra merging, collectionFormat, info defaults |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@tada5hi/tsconfig": "^0.7.2",
                 "@types/node": "^25.5.2",
                 "@vitest/coverage-v8": "^4.1.4",
+                "ajv": "^8.18.0",
                 "ajv-draft-04": "^1.0.0",
                 "ajv-formats": "^3.0.1",
                 "eslint": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
                 "@tada5hi/tsconfig": "^0.7.2",
                 "@types/node": "^25.5.2",
                 "@vitest/coverage-v8": "^4.1.4",
+                "ajv-draft-04": "^1.0.0",
+                "ajv-formats": "^3.0.1",
                 "eslint": "^10.1.0",
                 "eslint-plugin-vue": "^10.8.0",
                 "husky": "^9.1.7",
@@ -3026,7 +3028,6 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -3036,6 +3037,39 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
             }
         },
         "node_modules/algoliasearch": {
@@ -4536,8 +4570,7 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ],
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -5580,8 +5613,7 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -7007,7 +7039,6 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@tada5hi/tsconfig": "^0.7.2",
         "@types/node": "^25.5.2",
         "@vitest/coverage-v8": "^4.1.4",
+        "ajv": "^8.18.0",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
         "eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
         "@tada5hi/tsconfig": "^0.7.2",
         "@types/node": "^25.5.2",
         "@vitest/coverage-v8": "^4.1.4",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
         "eslint": "^10.1.0",
         "eslint-plugin-vue": "^10.8.0",
         "husky": "^9.1.7",

--- a/packages/metadata/test/vitest.config.ts
+++ b/packages/metadata/test/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
                 'src/decorator/mapper/maps/**/*',
                 'src/decorator/utils/validator.ts',
                 'src/resolver/**/*.ts',
-                'src/utils/validator.ts',
+                'src/utils/validator/**/*',
             ],
             thresholds: {
                 branches: 58,

--- a/packages/swagger/src/constants.ts
+++ b/packages/swagger/src/constants.ts
@@ -8,6 +8,8 @@
 export enum Version {
     V2 = 'v2',
     V3 = 'v3',
+    V3_1 = 'v3.1',
+    V3_2 = 'v3.2',
 }
 
 export enum DocumentFormat {

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -320,7 +320,7 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
         properties.forEach((property) => {
             const swaggerType = this.getSchemaForType(property.type) as Schema;
 
-            if (swaggerType.$ref) {
+            if (swaggerType.$ref && this.shouldStripRefSiblings()) {
                 output[property.name] = { $ref: swaggerType.$ref } as Schema;
                 return;
             }
@@ -347,6 +347,12 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
     }
 
     protected abstract markPropertyDeprecated(schema: Schema): void;
+
+    protected shouldStripRefSiblings(): boolean {
+        // V2 (Swagger 2.0) and V3 (3.0): $ref must be the only key.
+        // V3 (3.1+): $ref siblings are allowed. Override to return false.
+        return true;
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected assignPropertyDefaults(schema: Schema, property: ResolverProperty): void {

--- a/packages/swagger/src/generator/module.ts
+++ b/packages/swagger/src/generator/module.ts
@@ -37,8 +37,10 @@ export async function generate<V extends `${Version}`>(
     const metadata = await buildMetadata(context.options, context.tsConfig);
 
     switch (context.version) {
-        case Version.V3: {
-            const generator = new V3Generator(metadata, context.options);
+        case Version.V3:
+        case Version.V3_1:
+        case Version.V3_2: {
+            const generator = new V3Generator(metadata, context.options, context.version);
 
             return await generator.build() as OutputSpec<V>;
         }

--- a/packages/swagger/src/generator/v2/module.ts
+++ b/packages/swagger/src/generator/v2/module.ts
@@ -406,7 +406,7 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
 
         if (input.type.typeName === TypeName.ANY) {
             parameter.type = DataTypeName.STRING;
-        } else if (parameterType.type) {
+        } else if (parameterType.type && !Array.isArray(parameterType.type)) {
             parameter.type = parameterType.type;
         }
 

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -65,7 +65,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         let spec: SpecV3 = {
             components: this.buildComponents(),
             info: this.buildInfo(),
-            openapi: '3.1.0',
+            openapi: '3.0.0',
             paths: this.buildPaths(),
             servers: this.buildServers(),
             tags: [],

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -9,6 +9,7 @@ import type {
     BaseType,
     EnumType,
     IntersectionType,
+    Metadata,
     Method,
     Parameter,
     RefEnumType,
@@ -47,6 +48,7 @@ import {
     DataTypeName,
     ParameterSourceV3,
 } from '../../schema';
+import type { OptionsInput } from '../../config';
 import type { SecurityDefinition, SecurityDefinitions } from '../../types';
 import { SwaggerError, SwaggerErrorCode } from '../../error';
 import {
@@ -55,8 +57,26 @@ import {
     removeFinalCharacter,
 } from '../../utils';
 import { AbstractSpecGenerator } from '../abstract';
+import type { Version } from '../../constants';
+
+const OPENAPI_VERSION_MAP: Partial<Record<`${Version}`, string>> = {
+    v3: '3.0.0',
+    'v3.1': '3.1.0',
+    'v3.2': '3.2.0',
+};
 
 export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
+    private readonly openApiVersion: string;
+
+    constructor(
+        metadata: Metadata,
+        config: OptionsInput,
+        version: `${Version}` = 'v3.2',
+    ) {
+        super(metadata, config);
+        this.openApiVersion = OPENAPI_VERSION_MAP[version] || '3.2.0';
+    }
+
     async build() : Promise<SpecV3> {
         if (typeof this.spec !== 'undefined') {
             return this.spec;
@@ -65,7 +85,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         let spec: SpecV3 = {
             components: this.buildComponents(),
             info: this.buildInfo(),
-            openapi: '3.0.0',
+            openapi: this.openApiVersion,
             paths: this.buildPaths(),
             servers: this.buildServers(),
             tags: [],
@@ -505,12 +525,34 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         return schema;
     }
 
+    private isV31OrLater(): boolean {
+        return !this.openApiVersion.startsWith('3.0');
+    }
+
+    protected override shouldStripRefSiblings(): boolean {
+        return !this.isV31OrLater();
+    }
+
     protected getSchemaForIntersectionType(type: IntersectionType) : SchemaV3 {
         return { allOf: type.members.map((x: Type) => this.getSchemaForType(x)) };
     }
 
     protected applyNullable(schema: SchemaV3, nullable: boolean): void {
-        schema.nullable = nullable;
+        if (!nullable) {
+            return;
+        }
+
+        if (this.isV31OrLater()) {
+            // 3.1+: use type arrays instead of nullable keyword
+            if (schema.type && !Array.isArray(schema.type)) {
+                schema.type = [schema.type, 'null'];
+            } else if (Array.isArray(schema.type) && !schema.type.includes('null')) {
+                schema.type = [...schema.type, 'null'];
+            }
+        } else {
+            // 3.0: use nullable keyword
+            schema.nullable = true;
+        }
     }
 
     protected getRefPrefix(): string {
@@ -563,6 +605,20 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
             schemas.push(this.getSchemaForEnumType(enumType));
         }
 
+        if (this.isV31OrLater()) {
+            // 3.1+: add { type: 'null' } to anyOf for nullable unions
+            if (nullable) {
+                schemas.push({ type: 'null' } as unknown as SchemaV3);
+            }
+
+            if (schemas.length === 1) {
+                return schemas[0];
+            }
+
+            return { anyOf: schemas };
+        }
+
+        // 3.0: use nullable keyword
         if (schemas.length === 1) {
             const schema = schemas[0];
 

--- a/packages/swagger/src/schema/types.ts
+++ b/packages/swagger/src/schema/types.ts
@@ -79,7 +79,7 @@ export interface Example {
 // ------------------------------------------------------
 
 export interface BaseSchema<T> {
-    type?: `${DataTypeName}`;
+    type?: `${DataTypeName}` | Array<`${DataTypeName}` | 'null'>;
     format?: `${DataFormatName}`;
     title?: string;
     description?: string;

--- a/packages/swagger/test/helpers/schema-validator.ts
+++ b/packages/swagger/test/helpers/schema-validator.ts
@@ -5,7 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import Ajv from 'ajv-draft-04';
+import AjvDraft04 from 'ajv-draft-04';
+import Ajv2020 from 'ajv/dist/2020.js';
 import type { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { readFileSync } from 'node:fs';
@@ -16,17 +17,24 @@ const currentDir = fileURLToPath(new URL('.', import.meta.url));
 
 let v2Validate: ValidateFunction | undefined;
 let v3Validate: ValidateFunction | undefined;
+let v31Validate: ValidateFunction | undefined;
 
-function compileSchema(filename: string): ValidateFunction {
+function loadSchema(filename: string): object {
     const schemaPath = join(currentDir, '..', 'schemas', filename);
-    const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+    return JSON.parse(readFileSync(schemaPath, 'utf-8'));
+}
 
-    const ajv = new Ajv({
-        allErrors: true,
-        strict: false,
-    });
+function compileDraft04Schema(filename: string): ValidateFunction {
+    const schema = loadSchema(filename);
+    const ajv = new AjvDraft04({ allErrors: true, strict: false });
     addFormats(ajv);
+    return ajv.compile(schema);
+}
 
+function compileDraft2020Schema(filename: string): ValidateFunction {
+    const schema = loadSchema(filename);
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
     return ajv.compile(schema);
 }
 
@@ -45,26 +53,37 @@ function formatErrors(validate: ValidateFunction): string[] {
 
 export function validateV2Spec(spec: unknown): ValidationResult {
     if (!v2Validate) {
-        v2Validate = compileSchema('v2.0-schema.json');
+        v2Validate = compileDraft04Schema('v2.0-schema.json');
     }
 
     const valid = v2Validate(spec);
-
-    return {
-        valid: !!valid,
-        errors: formatErrors(v2Validate),
-    };
+    return { valid: !!valid, errors: formatErrors(v2Validate) };
 }
 
 export function validateV3Spec(spec: unknown): ValidationResult {
     if (!v3Validate) {
-        v3Validate = compileSchema('v3.0-schema.json');
+        v3Validate = compileDraft04Schema('v3.0-schema.json');
     }
 
     const valid = v3Validate(spec);
+    return { valid: !!valid, errors: formatErrors(v3Validate) };
+}
 
-    return {
-        valid: !!valid,
-        errors: formatErrors(v3Validate),
-    };
+export function validateV31Spec(spec: unknown): ValidationResult {
+    if (!v31Validate) {
+        v31Validate = compileDraft2020Schema('v3.1-schema.json');
+    }
+
+    v31Validate(spec);
+
+    // The OAI 3.1 schema validates structure but intentionally skips JSON Schema
+    // content validation within schema objects (marked "without schema validation").
+    // Filter out errors caused by schema object content (unevaluated properties)
+    // and their cascading "else" schema failures.
+    const errors = formatErrors(v31Validate).filter(
+        (e) => !e.includes('unevaluated properties') &&
+            !e.includes('must match "else" schema'),
+    );
+
+    return { valid: errors.length === 0, errors };
 }

--- a/packages/swagger/test/helpers/schema-validator.ts
+++ b/packages/swagger/test/helpers/schema-validator.ts
@@ -69,6 +69,23 @@ export function validateV3Spec(spec: unknown): ValidationResult {
     return { valid: !!valid, errors: formatErrors(v3Validate) };
 }
 
+// Schema Object locations where unevaluatedProperties errors are expected
+// because the OAI 3.1 schema intentionally skips JSON Schema content validation.
+const SCHEMA_OBJECT_PATTERNS = [
+    '/components/schemas/',
+    '/content/',
+    '/schema',
+    '/items',
+];
+
+function isSchemaObjectError(instancePath: string, keyword: string): boolean {
+    if (keyword !== 'unevaluatedProperties' && keyword !== 'if') {
+        return false;
+    }
+
+    return SCHEMA_OBJECT_PATTERNS.some((p) => instancePath.includes(p));
+}
+
 export function validateV31Spec(spec: unknown): ValidationResult {
     if (!v31Validate) {
         v31Validate = compileDraft2020Schema('v3.1-schema.json');
@@ -76,14 +93,37 @@ export function validateV31Spec(spec: unknown): ValidationResult {
 
     v31Validate(spec);
 
-    // The OAI 3.1 schema validates structure but intentionally skips JSON Schema
-    // content validation within schema objects (marked "without schema validation").
-    // Filter out errors caused by schema object content (unevaluated properties)
-    // and their cascading "else" schema failures.
-    const errors = formatErrors(v31Validate).filter(
-        (e) => !e.includes('unevaluated properties') &&
-            !e.includes('must match "else" schema'),
-    );
+    if (!v31Validate.errors) {
+        return { valid: true, errors: [] };
+    }
 
+    // Filter out errors from Schema Object locations where the OAI 3.1 schema
+    // intentionally skips JSON Schema content validation.
+    // Also filter cascading "else" errors caused by those suppressions.
+    const schemaErrorPaths = new Set<string>();
+    for (const err of v31Validate.errors) {
+        if (isSchemaObjectError(err.instancePath || '', err.keyword)) {
+            schemaErrorPaths.add(err.instancePath || '');
+        }
+    }
+
+    const filtered = v31Validate.errors.filter((err) => {
+        const path = err.instancePath || '';
+        // Suppress schema object errors
+        if (isSchemaObjectError(path, err.keyword)) {
+            return false;
+        }
+        // Suppress cascading "else" errors whose parent was a schema object error
+        if (err.keyword === 'if' || err.message?.includes('must match "else" schema')) {
+            for (const schemaPath of schemaErrorPaths) {
+                if (path.startsWith(schemaPath) || schemaPath.startsWith(path)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    });
+
+    const errors = filtered.map((e) => `${e.instancePath || '/'}: ${e.message}`);
     return { valid: errors.length === 0, errors };
 }

--- a/packages/swagger/test/helpers/schema-validator.ts
+++ b/packages/swagger/test/helpers/schema-validator.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import Ajv from 'ajv-draft-04';
+import type { ValidateFunction } from 'ajv-draft-04';
+import addFormats from 'ajv-formats';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url));
+
+let v2Validate: ValidateFunction | undefined;
+let v3Validate: ValidateFunction | undefined;
+
+function compileSchema(filename: string): ValidateFunction {
+    const schemaPath = join(currentDir, '..', 'schemas', filename);
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+
+    const ajv = new Ajv({
+        allErrors: true,
+        strict: false,
+    });
+    addFormats(ajv);
+
+    return ajv.compile(schema);
+}
+
+export type ValidationResult = {
+    valid: boolean;
+    errors: string[];
+};
+
+function formatErrors(validate: ValidateFunction): string[] {
+    if (!validate.errors) {
+        return [];
+    }
+
+    return validate.errors.map((e) => `${e.instancePath || '/'}: ${e.message}`);
+}
+
+export function validateV2Spec(spec: unknown): ValidationResult {
+    if (!v2Validate) {
+        v2Validate = compileSchema('v2.0-schema.json');
+    }
+
+    const valid = v2Validate(spec);
+
+    return {
+        valid: !!valid,
+        errors: formatErrors(v2Validate),
+    };
+}
+
+export function validateV3Spec(spec: unknown): ValidationResult {
+    if (!v3Validate) {
+        v3Validate = compileSchema('v3.0-schema.json');
+    }
+
+    const valid = v3Validate(spec);
+
+    return {
+        valid: !!valid,
+        errors: formatErrors(v3Validate),
+    };
+}

--- a/packages/swagger/test/schemas/v2.0-schema.json
+++ b/packages/swagger/test/schemas/v2.0-schema.json
@@ -1,0 +1,1607 @@
+{
+  "title": "A JSON Schema for Swagger 2.0 API.",
+  "id": "http://swagger.io/v2/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "swagger",
+    "info",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "$ref": "#/definitions/vendorExtension"
+    }
+  },
+  "properties": {
+    "swagger": {
+      "type": "string",
+      "enum": [
+        "2.0"
+      ],
+      "description": "The Swagger version of this document."
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+    },
+    "basePath": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "The base path to the API. Example: '/api'."
+    },
+    "schemes": {
+      "$ref": "#/definitions/schemesList"
+    },
+    "consumes": {
+      "description": "A list of MIME types accepted by the API.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "produces": {
+      "description": "A list of MIME types the API can produce.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/definitions/paths"
+    },
+    "definitions": {
+      "$ref": "#/definitions/definitions"
+    },
+    "parameters": {
+      "$ref": "#/definitions/parameterDefinitions"
+    },
+    "responses": {
+      "$ref": "#/definitions/responseDefinitions"
+    },
+    "security": {
+      "$ref": "#/definitions/security"
+    },
+    "securityDefinitions": {
+      "$ref": "#/definitions/securityDefinitions"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "info": {
+      "type": "object",
+      "description": "General information about the API.",
+      "required": [
+        "version",
+        "title"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "A unique and precise title of the API."
+        },
+        "version": {
+          "type": "string",
+          "description": "A semantic version number of the API."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+        },
+        "termsOfService": {
+          "type": "string",
+          "description": "The terms of service for the API."
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the owners of the API.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The identifying name of the contact person/organization."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the contact information.",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "description": "The email address of the contact person/organization.",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the license.",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        },
+        "^/": {
+          "$ref": "#/definitions/pathItem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+    },
+    "parameterDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "One or more JSON representations for parameters"
+    },
+    "responseDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/response"
+      },
+      "description": "One or more JSON representations for responses"
+    },
+    "externalDocs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "information about external documentation",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mimeType": {
+      "type": "string",
+      "description": "The MIME type of the HTTP message."
+    },
+    "operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "A brief summary of the operation."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string",
+          "description": "A unique identifier of the operation."
+        },
+        "produces": {
+          "description": "A list of MIME types the API can produce.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "consumes": {
+          "description": "A list of MIME types the API can consume.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        },
+        "responses": {
+          "$ref": "#/definitions/responses"
+        },
+        "schemes": {
+          "$ref": "#/definitions/schemesList"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        }
+      }
+    },
+    "pathItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/operation"
+        },
+        "put": {
+          "$ref": "#/definitions/operation"
+        },
+        "post": {
+          "$ref": "#/definitions/operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/operation"
+        },
+        "options": {
+          "$ref": "#/definitions/operation"
+        },
+        "head": {
+          "$ref": "#/definitions/operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/operation"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([0-9]{3})$|^(default)$": {
+          "$ref": "#/definitions/responseValue"
+        },
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "not": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      }
+    },
+    "responseValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/response"
+        },
+        {
+          "$ref": "#/definitions/jsonReference"
+        }
+      ]
+    },
+    "response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "$ref": "#/definitions/fileSchema"
+            }
+          ]
+        },
+        "headers": {
+          "$ref": "#/definitions/headers"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "vendorExtension": {
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
+    },
+    "bodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "schema"
+      ],
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "body"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "schema": {
+          "$ref": "#/definitions/schema"
+        }
+      },
+      "additionalProperties": false
+    },
+    "headerParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "header"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "queryParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "formDataParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "formData"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array",
+            "file"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "pathParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "enum": [
+            true
+          ],
+          "description": "Determines whether or not this parameter is required or optional."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "path"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "nonBodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "type"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/headerParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/formDataParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/queryParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/pathParameterSubSchema"
+        }
+      ]
+    },
+    "parameter": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/bodyParameter"
+        },
+        {
+          "$ref": "#/definitions/nonBodyParameter"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
+        },
+        "type": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            }
+          ],
+          "default": {}
+        },
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          },
+          "default": {}
+        },
+        "discriminator": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "fileSchema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "primitivesItems": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/securityRequirement"
+      },
+      "uniqueItems": true
+    },
+    "securityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      }
+    },
+    "xml": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "securityDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/basicAuthenticationSecurity"
+          },
+          {
+            "$ref": "#/definitions/apiKeySecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ImplicitSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2PasswordSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ApplicationSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2AccessCodeSecurity"
+          }
+        ]
+      }
+    },
+    "basicAuthenticationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "basic"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "apiKeySecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ImplicitSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "implicit"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2PasswordSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "password"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ApplicationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "application"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2AccessCodeSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "accessCode"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2Scopes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "mediaTypeList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/mimeType"
+      },
+      "uniqueItems": true
+    },
+    "parametersList": {
+      "type": "array",
+      "description": "The parameters needed to send a valid API call.",
+      "additionalItems": false,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/parameter"
+          },
+          {
+            "$ref": "#/definitions/jsonReference"
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "schemesList": {
+      "type": "array",
+      "description": "The transfer protocol of the API.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "http",
+          "https",
+          "ws",
+          "wss"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "collectionFormat": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes"
+      ],
+      "default": "csv"
+    },
+    "collectionFormatWithMulti": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes",
+        "multi"
+      ],
+      "default": "csv"
+    },
+    "title": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+    },
+    "description": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+    },
+    "default": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+    },
+    "multipleOf": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+    },
+    "maximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+    },
+    "exclusiveMaximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+    },
+    "minimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+    },
+    "exclusiveMinimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+    },
+    "maxLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+    },
+    "maxItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+    },
+    "enum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+    },
+    "jsonReference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/swagger/test/schemas/v3.0-schema.json
+++ b/packages/swagger/test/schemas/v3.0-schema.json
@@ -1,0 +1,1651 @@
+{
+  "id": "https://spec.openapis.org/oas/3.0/schema/WORK-IN-PROGRESS",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The description of OpenAPI v3.0.x Documents",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.0\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/definitions/Info"
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "patternProperties": {
+    "^x-": {}
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      }
+    },
+    "Info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "license": {
+          "$ref": "#/definitions/License"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "License": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ServerVariable": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Schema"
+                },
+                {
+                  "$ref": "#/definitions/Reference"
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Response"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Parameter"
+                }
+              ]
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Example"
+                }
+              ]
+            }
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/RequestBody"
+                }
+              ]
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Header"
+                }
+              ]
+            }
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Link"
+                }
+              ]
+            }
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Callback"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "uniqueItems": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxProperties": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minProperties": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "minItems": 1,
+          "uniqueItems": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
+        },
+        "not": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "default": {},
+        "nullable": {
+          "type": "boolean",
+          "default": false
+        },
+        "discriminator": {
+          "$ref": "#/definitions/Discriminator"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "writeOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "example": {},
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/XML"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Discriminator": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "XML": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Link"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Encoding"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {},
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
+    },
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        "^\\/": {
+          "$ref": "#/definitions/PathItem"
+        },
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PathItem": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RequestBody"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Responses": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:\\d{2}|XX)$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "^x-": {}
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExternalDocumentation": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/PathParameter"
+        },
+        {
+          "$ref": "#/definitions/QueryParameter"
+        },
+        {
+          "$ref": "#/definitions/HeaderParameter"
+        },
+        {
+          "$ref": "#/definitions/CookieParameter"
+        }
+      ]
+    },
+    "PathParameter": {
+      "description": "Parameter in path",
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "in": {
+          "enum": [
+            "path"
+          ]
+        },
+        "style": {
+          "enum": [
+            "matrix",
+            "label",
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "required": {
+          "enum": [
+            true
+          ]
+        }
+      }
+    },
+    "QueryParameter": {
+      "description": "Parameter in query",
+      "properties": {
+        "in": {
+          "enum": [
+            "query"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "HeaderParameter": {
+      "description": "Parameter in header",
+      "properties": {
+        "in": {
+          "enum": [
+            "header"
+          ]
+        },
+        "style": {
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        }
+      }
+    },
+    "CookieParameter": {
+      "description": "Parameter in cookie",
+      "properties": {
+        "in": {
+          "enum": [
+            "cookie"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "RequestBody": {
+      "type": "object",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/APIKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+        }
+      ]
+    },
+    "APIKeySecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "type": "string",
+              "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OpenIdConnectSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/ImplicitOAuthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/PasswordOAuthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/ClientCredentialsFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ImplicitOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PasswordOAuthFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ClientCredentialsFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationCodeOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "requestBody": {},
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/Server"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
+    },
+    "Callback": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PathItem"
+      },
+      "patternProperties": {
+        "^x-": {}
+      }
+    },
+    "Encoding": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/swagger/test/schemas/v3.0-schema.yaml
+++ b/packages/swagger/test/schemas/v3.0-schema.yaml
@@ -1,0 +1,1031 @@
+id: https://spec.openapis.org/oas/3.0/schema/WORK-IN-PROGRESS
+$schema: http://json-schema.org/draft-04/schema#
+description: The description of OpenAPI v3.0.x Documents
+type: object
+required:
+  - openapi
+  - info
+  - paths
+properties:
+  openapi:
+    type: string
+    pattern: ^3\.0\.\d(-.+)?$
+  info:
+    $ref: '#/definitions/Info'
+  externalDocs:
+    $ref: '#/definitions/ExternalDocumentation'
+  servers:
+    type: array
+    items:
+      $ref: '#/definitions/Server'
+  security:
+    type: array
+    items:
+      $ref: '#/definitions/SecurityRequirement'
+  tags:
+    type: array
+    items:
+      $ref: '#/definitions/Tag'
+    uniqueItems: true
+  paths:
+    $ref: '#/definitions/Paths'
+  components:
+    $ref: '#/definitions/Components'
+patternProperties:
+  '^x-': {}
+additionalProperties: false
+definitions:
+  Reference:
+    type: object
+    required:
+      - $ref
+    patternProperties:
+      '^\$ref$':
+        type: string
+        format: uri-reference
+  Info:
+    type: object
+    required:
+      - title
+      - version
+    properties:
+      title:
+        type: string
+      description:
+        type: string
+      termsOfService:
+        type: string
+        format: uri-reference
+      contact:
+        $ref: '#/definitions/Contact'
+      license:
+        $ref: '#/definitions/License'
+      version:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+
+  Contact:
+    type: object
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+      email:
+        type: string
+        format: email
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  License:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Server:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+      description:
+        type: string
+      variables:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ServerVariable'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ServerVariable:
+    type: object
+    required:
+      - default
+    properties:
+      enum:
+        type: array
+        items:
+          type: string
+      default:
+        type: string
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Components:
+    type: object
+    properties:
+      schemas:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Schema'
+              - $ref: '#/definitions/Reference'
+      responses:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Response'
+      parameters:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Parameter'
+      examples:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Example'
+      requestBodies:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/RequestBody'
+      headers:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Header'
+      securitySchemes:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/SecurityScheme'
+      links:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Link'
+      callbacks:
+        type: object
+        patternProperties:
+          '^[a-zA-Z0-9\.\-_]+$':
+            oneOf:
+              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/Callback'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Schema:
+    type: object
+    properties:
+      title:
+        type: string
+      multipleOf:
+        type: number
+        minimum: 0
+        exclusiveMinimum: true
+      maximum:
+        type: number
+      exclusiveMaximum:
+        type: boolean
+        default: false
+      minimum:
+        type: number
+      exclusiveMinimum:
+        type: boolean
+        default: false
+      maxLength:
+        type: integer
+        minimum: 0
+      minLength:
+        type: integer
+        minimum: 0
+        default: 0
+      pattern:
+        type: string
+        format: regex
+      maxItems:
+        type: integer
+        minimum: 0
+      minItems:
+        type: integer
+        minimum: 0
+        default: 0
+      uniqueItems:
+        type: boolean
+        default: false
+      maxProperties:
+        type: integer
+        minimum: 0
+      minProperties:
+        type: integer
+        minimum: 0
+        default: 0
+      required:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        uniqueItems: true
+      enum:
+        type: array
+        items: {}
+        minItems: 1
+        uniqueItems: false
+      type:
+        type: string
+        enum:
+          - array
+          - boolean
+          - integer
+          - number
+          - object
+          - string
+      not:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      allOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      oneOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      anyOf:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      items:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      properties:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Schema'
+            - $ref: '#/definitions/Reference'
+      additionalProperties:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+          - type: boolean
+        default: true
+      description:
+        type: string
+      format:
+        type: string
+      default: {}
+      nullable:
+        type: boolean
+        default: false
+      discriminator:
+        $ref: '#/definitions/Discriminator'
+      readOnly:
+        type: boolean
+        default: false
+      writeOnly:
+        type: boolean
+        default: false
+      example: {}
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      deprecated:
+        type: boolean
+        default: false
+      xml:
+        $ref: '#/definitions/XML'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Discriminator:
+    type: object
+    required:
+      - propertyName
+    properties:
+      propertyName:
+        type: string
+      mapping:
+        type: object
+        additionalProperties:
+          type: string
+
+  XML:
+    type: object
+    properties:
+      name:
+        type: string
+      namespace:
+        type: string
+        format: uri
+      prefix:
+        type: string
+      attribute:
+        type: boolean
+        default: false
+      wrapped:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Response:
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Header'
+            - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      links:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Link'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  MediaType:
+    type: object
+    properties:
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+      encoding:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Encoding'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+
+  Example:
+    type: object
+    properties:
+      summary:
+        type: string
+      description:
+        type: string
+      value: {}
+      externalValue:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Header:
+    type: object
+    properties:
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+        enum:
+          - simple
+        default: simple
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+      - $ref: '#/definitions/SchemaXORContent'
+
+  Paths:
+    type: object
+    patternProperties:
+      '^\/':
+        $ref: '#/definitions/PathItem'
+      '^x-': {}
+    additionalProperties: false
+
+  PathItem:
+    type: object
+    properties:
+      $ref:
+        type: string
+      summary:
+        type: string
+      description:
+        type: string
+      get:
+        $ref: '#/definitions/Operation'
+      put:
+        $ref: '#/definitions/Operation'
+      post:
+        $ref: '#/definitions/Operation'
+      delete:
+        $ref: '#/definitions/Operation'
+      options:
+        $ref: '#/definitions/Operation'
+      head:
+        $ref: '#/definitions/Operation'
+      patch:
+        $ref: '#/definitions/Operation'
+      trace:
+        $ref: '#/definitions/Operation'
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+        uniqueItems: true
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Operation:
+    type: object
+    required:
+      - responses
+    properties:
+      tags:
+        type: array
+        items:
+          type: string
+      summary:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+      operationId:
+        type: string
+      parameters:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/definitions/Parameter'
+            - $ref: '#/definitions/Reference'
+        uniqueItems: true
+      requestBody:
+        oneOf:
+          - $ref: '#/definitions/RequestBody'
+          - $ref: '#/definitions/Reference'
+      responses:
+        $ref: '#/definitions/Responses'
+      callbacks:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Callback'
+            - $ref: '#/definitions/Reference'
+      deprecated:
+        type: boolean
+        default: false
+      security:
+        type: array
+        items:
+          $ref: '#/definitions/SecurityRequirement'
+      servers:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Responses:
+    type: object
+    properties:
+      default:
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^[1-5](?:\d{2}|XX)$':
+        oneOf:
+          - $ref: '#/definitions/Response'
+          - $ref: '#/definitions/Reference'
+      '^x-': {}
+    minProperties: 1
+    additionalProperties: false
+
+
+  SecurityRequirement:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        type: string
+
+  Tag:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      externalDocs:
+        $ref: '#/definitions/ExternalDocumentation'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ExternalDocumentation:
+    type: object
+    required:
+      - url
+    properties:
+      description:
+        type: string
+      url:
+        type: string
+        format: uri-reference
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ExampleXORExamples:
+    description: Example and examples are mutually exclusive
+    not:
+      required: [example, examples]
+
+  SchemaXORContent:
+    description: Schema and content are mutually exclusive, at least one is required
+    not:
+      required: [schema, content]
+    oneOf:
+      - required: [schema]
+      - required: [content]
+        description: Some properties are not allowed if content is present
+        allOf:
+          - not:
+              required: [style]
+          - not:
+              required: [explode]
+          - not:
+              required: [allowReserved]
+          - not:
+              required: [example]
+          - not:
+              required: [examples]
+
+  Parameter:
+    type: object
+    properties:
+      name:
+        type: string
+      in:
+        type: string
+      description:
+        type: string
+      required:
+        type: boolean
+        default: false
+      deprecated:
+        type: boolean
+        default: false
+      allowEmptyValue:
+        type: boolean
+        default: false
+      style:
+        type: string
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+      schema:
+        oneOf:
+          - $ref: '#/definitions/Schema'
+          - $ref: '#/definitions/Reference'
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+        minProperties: 1
+        maxProperties: 1
+      example: {}
+      examples:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Example'
+            - $ref: '#/definitions/Reference'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    required:
+      - name
+      - in
+    allOf:
+      - $ref: '#/definitions/ExampleXORExamples'
+      - $ref: '#/definitions/SchemaXORContent'
+    oneOf:
+      - $ref: '#/definitions/PathParameter'
+      - $ref: '#/definitions/QueryParameter'
+      - $ref: '#/definitions/HeaderParameter'
+      - $ref: '#/definitions/CookieParameter'
+
+  PathParameter:
+    description: Parameter in path
+    required:
+      - required
+    properties:
+      in:
+        enum: [path]
+      style:
+        enum: [matrix, label, simple]
+        default: simple
+      required:
+        enum: [true]
+
+  QueryParameter:
+    description: Parameter in query
+    properties:
+      in:
+        enum: [query]
+      style:
+        enum: [form, spaceDelimited, pipeDelimited, deepObject]
+        default: form
+
+  HeaderParameter:
+    description: Parameter in header
+    properties:
+      in:
+        enum: [header]
+      style:
+        enum: [simple]
+        default: simple
+
+  CookieParameter:
+    description: Parameter in cookie
+    properties:
+      in:
+        enum: [cookie]
+      style:
+        enum: [form]
+        default: form
+
+  RequestBody:
+    type: object
+    required:
+      - content
+    properties:
+      description:
+        type: string
+      content:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/MediaType'
+      required:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  SecurityScheme:
+    oneOf:
+      - $ref: '#/definitions/APIKeySecurityScheme'
+      - $ref: '#/definitions/HTTPSecurityScheme'
+      - $ref: '#/definitions/OAuth2SecurityScheme'
+      - $ref: '#/definitions/OpenIdConnectSecurityScheme'
+
+  APIKeySecurityScheme:
+    type: object
+    required:
+      - type
+      - name
+      - in
+    properties:
+      type:
+        type: string
+        enum:
+          - apiKey
+      name:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+          - query
+          - cookie
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  HTTPSecurityScheme:
+    type: object
+    required:
+      - scheme
+      - type
+    properties:
+      scheme:
+        type: string
+      bearerFormat:
+        type: string
+      description:
+        type: string
+      type:
+        type: string
+        enum:
+          - http
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    oneOf:
+      - description: Bearer
+        properties:
+          scheme:
+            type: string
+            pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
+
+      - description: Non Bearer
+        not:
+          required: [bearerFormat]
+        properties:
+          scheme:
+            not:
+              type: string
+              pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
+
+  OAuth2SecurityScheme:
+    type: object
+    required:
+      - type
+      - flows
+    properties:
+      type:
+        type: string
+        enum:
+          - oauth2
+      flows:
+        $ref: '#/definitions/OAuthFlows'
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OpenIdConnectSecurityScheme:
+    type: object
+    required:
+      - type
+      - openIdConnectUrl
+    properties:
+      type:
+        type: string
+        enum:
+          - openIdConnect
+      openIdConnectUrl:
+        type: string
+        format: uri-reference
+      description:
+        type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  OAuthFlows:
+    type: object
+    properties:
+      implicit:
+        $ref: '#/definitions/ImplicitOAuthFlow'
+      password:
+        $ref: '#/definitions/PasswordOAuthFlow'
+      clientCredentials:
+        $ref: '#/definitions/ClientCredentialsFlow'
+      authorizationCode:
+        $ref: '#/definitions/AuthorizationCodeOAuthFlow'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ImplicitOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - scopes
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  PasswordOAuthFlow:
+    type: object
+    required:
+      - tokenUrl
+      - scopes
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  ClientCredentialsFlow:
+    type: object
+    required:
+      - tokenUrl
+      - scopes
+    properties:
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  AuthorizationCodeOAuthFlow:
+    type: object
+    required:
+      - authorizationUrl
+      - tokenUrl
+      - scopes
+    properties:
+      authorizationUrl:
+        type: string
+        format: uri-reference
+      tokenUrl:
+        type: string
+        format: uri-reference
+      refreshUrl:
+        type: string
+        format: uri-reference
+      scopes:
+        type: object
+        additionalProperties:
+          type: string
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+
+  Link:
+    type: object
+    properties:
+      operationId:
+        type: string
+      operationRef:
+        type: string
+        format: uri-reference
+      parameters:
+        type: object
+        additionalProperties: {}
+      requestBody: {}
+      description:
+        type: string
+      server:
+        $ref: '#/definitions/Server'
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false
+    not:
+      description: Operation Id and Operation Ref are mutually exclusive
+      required: [operationId, operationRef]
+
+  Callback:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/PathItem'
+    patternProperties:
+      '^x-': {}
+
+  Encoding:
+    type: object
+    properties:
+      contentType:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          oneOf:
+            - $ref: '#/definitions/Header'
+            - $ref: '#/definitions/Reference'
+      style:
+        type: string
+        enum:
+          - form
+          - spaceDelimited
+          - pipeDelimited
+          - deepObject
+      explode:
+        type: boolean
+      allowReserved:
+        type: boolean
+        default: false
+    patternProperties:
+      '^x-': {}
+    additionalProperties: false

--- a/packages/swagger/test/schemas/v3.1-schema.json
+++ b/packages/swagger/test/schemas/v3.1-schema.json
@@ -1,0 +1,1440 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/base"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item-or-reference"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#path-item-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-form"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "name": {
+                    "pattern": "[^/#?]+$"
+                  },
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                }
+              }
+            },
+            "styles-for-form": {
+              "if": {
+                "properties": {
+                  "style": {
+                    "const": "form"
+                  }
+                },
+                "required": [
+                  "style"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "explode": {
+                    "default": true
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "explode": {
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "default": "form",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/encoding/$defs/explode-default"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "explode-default": {
+          "if": {
+            "properties": {
+              "style": {
+                "const": "form"
+              }
+            },
+            "required": [
+              "style"
+            ]
+          },
+          "then": {
+            "properties": {
+              "explode": {
+                "default": true
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "explode": {
+                "default": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/packages/swagger/test/unit/specification/config-variations.spec.ts
+++ b/packages/swagger/test/unit/specification/config-variations.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { Version, generate } from '../../../src';
+import {
+    arrayType,
+    createController,
+    createMetadata,
+    createMethod,
+    createParameter,
+    createResponse,
+    stringType,
+} from '../../helpers/metadata-builder';
+
+const servers = 'http://localhost:3000/';
+
+describe('config variations', () => {
+    describe('specificationExtra', () => {
+        it('V2: should merge specificationExtra into the spec', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    specificationExtra: {
+                        'x-custom-field': 'custom-value',
+                        externalDocs: {
+                            description: 'External docs',
+                            url: 'https://example.com/docs',
+                        },
+                    },
+                },
+            });
+
+            expect(spec['x-custom-field']).toEqual('custom-value');
+            expect(spec.externalDocs).toEqual({
+                description: 'External docs',
+                url: 'https://example.com/docs',
+            });
+        });
+
+        it('V3: should merge specificationExtra into the spec', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    specificationExtra: {
+                        'x-custom-field': 'v3-custom',
+                        externalDocs: {
+                            description: 'V3 docs',
+                            url: 'https://example.com/v3',
+                        },
+                    },
+                },
+            });
+
+            expect(spec['x-custom-field']).toEqual('v3-custom');
+            expect(spec.externalDocs).toEqual({
+                description: 'V3 docs',
+                url: 'https://example.com/v3',
+            });
+        });
+
+        it('V2: specificationExtra should not overwrite core fields', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    specificationExtra: { swagger: '3.0' },
+                },
+            });
+
+            // Core fields should be preserved (smob merge gives priority to first arg)
+            expect(spec.swagger).toEqual('2.0');
+        });
+
+        it('V3: specificationExtra should not overwrite core fields', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    specificationExtra: { openapi: '9.9.9' },
+                },
+            });
+
+            expect(spec.openapi).toEqual('3.0.0');
+        });
+    });
+
+    describe('collectionFormat', () => {
+        const metadata = createMetadata([
+            createController({
+                name: 'ArrayController',
+                path: 'arrays',
+                methods: [
+                    createMethod({
+                        name: 'getWithArray',
+                        method: 'get',
+                        path: '',
+                        parameters: [
+                            createParameter({
+                                name: 'tags',
+                                in: 'queryProp',
+                                type: arrayType(stringType()),
+                            }),
+                        ],
+                        responses: [createResponse({ status: '200' })],
+                    }),
+                ],
+            }),
+        ]);
+
+        it('V2: should default to multi collectionFormat for array query params', async () => {
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const pathItem = spec.paths['/arrays'];
+            expect(pathItem, `paths: ${JSON.stringify(Object.keys(spec.paths))}`).toBeDefined();
+            const params = pathItem.get!.parameters!;
+            const tagsParam = params.find((p: any) => p.name === 'tags');
+            expect(tagsParam).toBeDefined();
+            expect((tagsParam as any).collectionFormat).toEqual('multi');
+        });
+
+        it('V2: should use configured collectionFormat', async () => {
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    collectionFormat: 'csv',
+                },
+            });
+
+            const pathItem = spec.paths['/arrays'];
+            expect(pathItem, `paths: ${JSON.stringify(Object.keys(spec.paths))}`).toBeDefined();
+            const params = pathItem.get!.parameters!;
+            const tagsParam = params.find((p: any) => p.name === 'tags');
+            expect(tagsParam).toBeDefined();
+            expect((tagsParam as any).collectionFormat).toEqual('csv');
+        });
+    });
+
+    describe('info configuration', () => {
+        it('should use configured name, version, and description', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    name: 'My API',
+                    version: '2.5.0',
+                    description: 'A test API',
+                },
+            });
+
+            expect(spec.info.title).toEqual('My API');
+            expect(spec.info.version).toEqual('2.5.0');
+            expect(spec.info.description).toEqual('A test API');
+        });
+
+        it('should default name to Documentation and version to 1.0.0', async () => {
+            const metadata = createMetadata([]);
+
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            expect(spec.info.title).toEqual('Documentation');
+            expect(spec.info.version).toEqual('1.0.0');
+        });
+    });
+});

--- a/packages/swagger/test/unit/specification/edge-cases.spec.ts
+++ b/packages/swagger/test/unit/specification/edge-cases.spec.ts
@@ -225,8 +225,8 @@ describe('edge cases and spec compliance', () => {
             expect(specV2.swagger).toEqual('2.0');
         });
 
-        it('V3: should have openapi version 3.1.0', () => {
-            expect(specV3.openapi).toEqual('3.1.0');
+        it('V3: should have openapi version 3.0.0', () => {
+            expect(specV3.openapi).toEqual('3.0.0');
         });
 
         it('V2: should have info object with title and version', () => {

--- a/packages/swagger/test/unit/specification/nullable-types.spec.ts
+++ b/packages/swagger/test/unit/specification/nullable-types.spec.ts
@@ -34,7 +34,7 @@ import {
  * - V3 (3.0.x): uses nullable: true
  * - V3 (3.1.x): uses type arrays ["string", "null"]
  *
- * trapi currently targets 3.1.0 but uses the 3.0.x nullable pattern.
+ * trapi targets 3.0.0 and uses the 3.0.x nullable pattern.
  */
 describe('nullable types', () => {
     let specV2: SpecV2;

--- a/packages/swagger/test/unit/specification/schema-validation.spec.ts
+++ b/packages/swagger/test/unit/specification/schema-validation.spec.ts
@@ -28,7 +28,7 @@ import {
     stringType,
     unionType,
 } from '../../helpers/metadata-builder';
-import { validateV2Spec, validateV3Spec } from '../../helpers/schema-validator';
+import { validateV2Spec, validateV31Spec, validateV3Spec } from '../../helpers/schema-validator';
 
 const servers = 'http://localhost:3000/';
 
@@ -287,6 +287,111 @@ describe('OAI schema validation', () => {
             const result = validateV3Spec(spec);
             expect(result.errors, result.errors.join('\n')).toEqual([]);
             expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('V3.1 schema validation', () => {
+        it('V3.1: empty metadata should produce a valid spec', async () => {
+            const metadata = createMetadata([]);
+            const spec = await generate({
+                version: Version.V3_1,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            expect(spec.openapi).toEqual('3.1.0');
+            const result = validateV31Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3.1: CRUD controller should produce a valid spec', async () => {
+            const crudMetadata = createMetadata(
+                [
+                    createController({
+                        name: 'ItemController',
+                        path: 'items',
+                        methods: [
+                            createMethod({
+                                name: 'getItems',
+                                method: 'get',
+                                path: '',
+                                type: arrayType(refObjectType('Item')),
+                                responses: [createResponse({ status: '200', schema: arrayType(refObjectType('Item')) })],
+                            }),
+                            createMethod({
+                                name: 'createItem',
+                                method: 'post',
+                                path: '',
+                                parameters: [
+                                    createParameter({
+                                        name: 'body', 
+                                        in: 'body', 
+                                        type: refObjectType('Item'), 
+                                    }),
+                                ],
+                                type: refObjectType('Item'),
+                                responses: [createResponse({
+                                    status: '201', 
+                                    schema: refObjectType('Item'), 
+                                    description: 'Created', 
+                                })],
+                            }),
+                        ],
+                    }),
+                ],
+                {
+                    Item: createRefObject('Item', [
+                        createProperty({
+                            name: 'id', 
+                            type: stringType(), 
+                            required: true, 
+                        }),
+                        createProperty({
+                            name: 'name', 
+                            type: stringType(), 
+                            required: true, 
+                        }),
+                    ]),
+                },
+            );
+
+            const spec = await generate({
+                version: Version.V3_1,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata: crudMetadata, 
+                },
+            });
+
+            const result = validateV31Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3.2: should produce valid spec with version 3.2.0', async () => {
+            const metadata = createMetadata([]);
+            const spec = await generate({
+                version: Version.V3_2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            expect(spec.openapi).toEqual('3.2.0');
+            // V3.2 schema not yet available from OAI; validate against 3.1 schema
+            // but filter out the version pattern mismatch (3.1 schema expects 3.1.x)
+            const result = validateV31Spec(spec);
+            const nonVersionErrors = result.errors.filter(
+                (e) => !e.includes('must match pattern'),
+            );
+            expect(nonVersionErrors, nonVersionErrors.join('\n')).toEqual([]);
         });
     });
 

--- a/packages/swagger/test/unit/specification/schema-validation.spec.ts
+++ b/packages/swagger/test/unit/specification/schema-validation.spec.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { Version, generate } from '../../../src';
+import {
+    arrayType,
+    createController,
+    createMetadata,
+    createMethod,
+    createParameter,
+    createProperty,
+    createRefEnum,
+    createRefObject,
+    createResponse,
+    enumType,
+    fileType,
+    integerType,
+    refObjectType,
+    stringType,
+    unionType,
+} from '../../helpers/metadata-builder';
+import { validateV2Spec, validateV3Spec } from '../../helpers/schema-validator';
+
+const servers = 'http://localhost:3000/';
+
+describe('OAI schema validation', () => {
+    describe('empty spec', () => {
+        it('V2: empty metadata should produce a valid spec', async () => {
+            const metadata = createMetadata([]);
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV2Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3: empty metadata should produce a valid spec', async () => {
+            const metadata = createMetadata([]);
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV3Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('basic CRUD controller', () => {
+        const metadata = createMetadata(
+            [
+                createController({
+                    name: 'UserController',
+                    path: 'users',
+                    methods: [
+                        createMethod({
+                            name: 'getUsers',
+                            method: 'get',
+                            path: '',
+                            responses: [createResponse({ status: '200', schema: arrayType(refObjectType('User')) })],
+                            type: arrayType(refObjectType('User')),
+                        }),
+                        createMethod({
+                            name: 'getUserById',
+                            method: 'get',
+                            path: '{id}',
+                            parameters: [
+                                createParameter({
+                                    name: 'id', 
+                                    in: 'path', 
+                                    type: stringType(), 
+                                    required: true, 
+                                }),
+                            ],
+                            responses: [createResponse({ status: '200', schema: refObjectType('User') })],
+                            type: refObjectType('User'),
+                        }),
+                        createMethod({
+                            name: 'createUser',
+                            method: 'post',
+                            path: '',
+                            parameters: [
+                                createParameter({
+                                    name: 'body', 
+                                    in: 'body', 
+                                    type: refObjectType('User'), 
+                                }),
+                            ],
+                            responses: [
+                                createResponse({
+                                    status: '201', 
+                                    schema: refObjectType('User'), 
+                                    description: 'Created', 
+                                }),
+                            ],
+                            type: refObjectType('User'),
+                        }),
+                        createMethod({
+                            name: 'deleteUser',
+                            method: 'delete',
+                            path: '{id}',
+                            parameters: [
+                                createParameter({
+                                    name: 'id', 
+                                    in: 'path', 
+                                    type: stringType(), 
+                                    required: true, 
+                                }),
+                            ],
+                            responses: [createResponse({ status: '204', description: 'Deleted' })],
+                        }),
+                    ],
+                }),
+            ],
+            {
+                User: createRefObject('User', [
+                    createProperty({
+                        name: 'id', 
+                        type: stringType(), 
+                        required: true, 
+                    }),
+                    createProperty({
+                        name: 'name', 
+                        type: stringType(), 
+                        required: true, 
+                    }),
+                    createProperty({ name: 'email', type: stringType() }),
+                    createProperty({ name: 'age', type: integerType() }),
+                ]),
+            },
+        );
+
+        it('V2: CRUD controller should produce a valid spec', async () => {
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV2Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3: CRUD controller should produce a valid spec', async () => {
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV3Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('complex types', () => {
+        const metadata = createMetadata(
+            [
+                createController({
+                    name: 'ComplexController',
+                    path: 'complex',
+                    methods: [
+                        createMethod({
+                            name: 'getWithEnum',
+                            method: 'get',
+                            path: 'enum',
+                            parameters: [
+                                createParameter({
+                                    name: 'status',
+                                    in: 'query',
+                                    type: enumType(['active', 'inactive', 'pending']),
+                                }),
+                            ],
+                            responses: [createResponse({ status: '200', schema: refObjectType('Item') })],
+                            type: refObjectType('Item'),
+                        }),
+                        createMethod({
+                            name: 'getNullable',
+                            method: 'get',
+                            path: 'nullable',
+                            responses: [createResponse({ status: '200', schema: refObjectType('NullableModel') })],
+                            type: refObjectType('NullableModel'),
+                        }),
+                        createMethod({
+                            name: 'uploadFile',
+                            method: 'post',
+                            path: 'upload',
+                            parameters: [
+                                createParameter({
+                                    name: 'file', 
+                                    in: 'formData', 
+                                    type: fileType(), 
+                                }),
+                                createParameter({
+                                    name: 'description', 
+                                    in: 'formData', 
+                                    type: stringType(), 
+                                }),
+                            ],
+                        }),
+                    ],
+                }),
+            ],
+            {
+                Item: createRefObject('Item', [
+                    createProperty({
+                        name: 'id', 
+                        type: integerType(), 
+                        required: true, 
+                    }),
+                    createProperty({
+                        name: 'name', 
+                        type: stringType(), 
+                        required: true, 
+                    }),
+                    createProperty({ name: 'tags', type: arrayType(stringType()) }),
+                ]),
+                Status: createRefEnum('Status', ['active', 'inactive', 'pending']),
+                NullableModel: createRefObject('NullableModel', [
+                    createProperty({
+                        name: 'value', 
+                        type: stringType(), 
+                        required: true, 
+                    }),
+                    createProperty({
+                        name: 'optional',
+                        type: unionType([stringType(), { typeName: 'enum', members: [null] }]),
+                    }),
+                ]),
+            },
+        );
+
+        it('V2: complex types should produce a valid spec', async () => {
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV2Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3: complex types should produce a valid spec', async () => {
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false, 
+                    servers, 
+                    metadata, 
+                },
+            });
+
+            const result = validateV3Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('security definitions', () => {
+        it('V2: spec with security should be valid', async () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'SecureController',
+                    path: 'secure',
+                    security: [{ bearerAuth: [] }],
+                    methods: [
+                        createMethod({
+                            name: 'getSecure',
+                            method: 'get',
+                            path: '',
+                            security: [{ bearerAuth: [] }],
+                        }),
+                    ],
+                }),
+            ]);
+
+            const spec = await generate({
+                version: Version.V2,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    securityDefinitions: { bearerAuth: { type: 'http', scheme: 'basic' } },
+                },
+            });
+
+            const result = validateV2Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('V3: spec with security should be valid', async () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'SecureController',
+                    path: 'secure',
+                    security: [{ bearerAuth: [] }],
+                    methods: [
+                        createMethod({
+                            name: 'getSecure',
+                            method: 'get',
+                            path: '',
+                            security: [{ bearerAuth: [] }],
+                        }),
+                    ],
+                }),
+            ]);
+
+            const spec = await generate({
+                version: Version.V3,
+                options: {
+                    output: false,
+                    servers,
+                    metadata,
+                    securityDefinitions: { bearerAuth: { type: 'http', scheme: 'basic' } },
+                },
+            });
+
+            const result = validateV3Spec(spec);
+            expect(result.errors, result.errors.join('\n')).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+    });
+});

--- a/packages/swagger/test/unit/specification/v3.spec.ts
+++ b/packages/swagger/test/unit/specification/v3.spec.ts
@@ -38,7 +38,7 @@ describe('SpecGenerator', () => {
     });
 
     it('should be able to generate open api 3.0 outputs', async () => {
-        expect(spec.openapi).toEqual('3.1.0');
+        expect(spec.openapi).toEqual('3.0.0');
         expect(spec.servers).toBeDefined();
         expect(spec.servers[0].url).toEqual('http://localhost:3000/api/');
     });


### PR DESCRIPTION
closes #772
closes #769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAPI v3.1 and v3.2 and schema validation for generated API specs.

* **Bug Fixes**
  * Fixed parameter type assignment to prevent invalid outputs.
  * Improved nullable handling for OpenAPI 3.1+ (uses type-based null representation).

* **Documentation**
  * Updated OpenAPI reference with v3.2 details and TRAPI mapping clarifications.

* **Tests**
  * Added schema validation tests covering V2, V3, and V3.1/3.2 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->