### PR TITLE
feat(metadata): add extended utility type support and unify resolution

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -13,7 +13,7 @@ TypeScript Source Code → Metadata Extraction → OpenAPI Specification
 
 2. **Type Resolution** — The `resolver/` module walks TypeScript's type system to resolve interfaces, generics, unions, intersections, and utility types into a normalized type representation. This is the most complex part of the codebase.
 
-3. **Spec Generation** — The swagger package takes the normalized metadata and produces OpenAPI 2.0 or 3.0 JSON/YAML output.
+3. **Spec Generation** — The swagger package takes the normalized metadata and produces OpenAPI 2.0 or 3.0 JSON/YAML output. Lossy conversions (e.g. tuples → arrays) happen here, never in the metadata layer.
 
 ## Metadata Generation
 
@@ -75,6 +75,16 @@ The abstract generator handles shared logic: schema building, reference resoluti
 - `resolveAdditionalProperties()` — `true` (V2) vs resolved type schema (V3)
 
 Version-specific generators handle structural format differences (e.g., `requestBody` in V3 vs `in: body` parameters in V2, `allOf` composition in V3 vs flattened properties in V2).
+
+## Metadata Fidelity Principle
+
+The metadata package (`@trapi/metadata`) must faithfully represent TypeScript's type system. When a TypeScript construct has no direct OpenAPI equivalent (e.g. tuples, branded types), the metadata layer must still model it accurately with a dedicated type (e.g. `TupleType` with named elements). Simplifications and lossy conversions for OpenAPI constraints happen exclusively in the swagger package (`@trapi/swagger`).
+
+**Never collapse a TypeScript concept in the metadata layer to fit OpenAPI.** The metadata is a general-purpose intermediate representation — other consumers (routing code generators, validation libraries, documentation tools) may need the full type information.
+
+Examples:
+- Tuples → metadata emits `TupleType` with per-element names and types; swagger converts to `array` with `anyOf` items
+- Intersection types → metadata emits `IntersectionType` with members; V2 swagger flattens to properties, V3 uses `allOf`
 
 ## Caching
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -82,6 +82,39 @@ packages/swagger/test/
 - **Swagger tests (spec compliance)** construct metadata inline using `test/helpers/metadata-builder.ts` factory functions, generate specs, and assert directly on the output objects. This pattern is self-contained, tests exactly one behavior per test, and doesn't depend on shared fixture files.
 - Tests that need the TypeScript compiler create a program from fixture files and pass it to the generators
 
+## Assertion Conventions
+
+### Assert the exact shape — never branch on type
+
+**Bad** — conditional assertions silently pass when no branch matches:
+```typescript
+if (type.typeName === 'refAlias') {
+    expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+} else if (type.typeName === 'refObject') {
+    expect(obj.properties).toContain('name');
+}
+// If typeName is neither → zero assertions run, test passes silently
+```
+
+**Good** — assert the concrete shape directly:
+```typescript
+expect(type.typeName).toEqual('refAlias');
+const alias = type as RefAliasType;
+expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+```
+
+### Why this matters
+
+The metadata resolver's output shape for a given input is deterministic. Tests should pin the exact shape, not hedge across possibilities. If the output shape changes, the test should fail explicitly — not silently pass through a different branch.
+
+### Rules
+
+1. **No `if/else` on `typeName`** — assert the expected `typeName` directly with `expect().toEqual()`. If the shape genuinely varies, write separate tests for each case.
+2. **No helpers that return `undefined` on mismatch** — helpers that silently return `undefined` when the type doesn't match (e.g., `findObjectLiteral`) mask failures. Assert the type before unwrapping.
+3. **Always verify leaf values** — don't stop at `expect(method).toBeDefined()`. Assert property names, property types, required flags, and ref names.
+4. **Test fixture types must be used as return types** — if a type alias is defined in a test fixture, it must appear as an actual method return type. Unused type aliases don't test resolution.
+5. **Verify `refName` on reference types** — always check `refName` to confirm the right type alias or object was resolved.
+
 ## Swagger Spec Compliance Tests
 
 The following test files use inline metadata to verify OpenAPI compliance:

--- a/packages/decorators/test/data/controllers/utility-types.ts
+++ b/packages/decorators/test/data/controllers/utility-types.ts
@@ -6,8 +6,8 @@
  */
 
 import {
-    Controller, 
-    Get, 
+    Controller,
+    Get,
     Mount,
 } from '../../../src';
 
@@ -19,6 +19,27 @@ type Foo = {
 type FooBar = Pick<Foo, 'bar'>;
 type FooBaz = Omit<Foo, 'bar'>;
 type FooPartial = Partial<Foo>;
+
+// Checker-resolvable utility types
+type Status = 'active' | 'inactive' | 'deleted';
+type ActiveStatus = Extract<Status, 'active' | 'inactive'>;
+type NonDeletedStatus = Exclude<Status, 'deleted'>;
+
+function createFoo(): Foo {
+    return { bar: 'a', baz: 'b' };
+}
+type FooReturn = ReturnType<typeof createFoo>;
+
+type FooParams = Parameters<typeof createFoo>;
+
+type AwaitedFoo = Awaited<Promise<Foo>>;
+type AwaitedNested = Awaited<Promise<Promise<Foo>>>;
+
+class FooFactory {
+    constructor(public name: string, public count: number) {}
+}
+type FooInstance = InstanceType<typeof FooFactory>;
+type FooCtorParams = ConstructorParameters<typeof FooFactory>;
 
 @Controller()
 @Mount('utility-types')
@@ -39,5 +60,41 @@ export class UtilityTypes {
     @Mount('partial')
     public partial(): FooPartial {
         return {};
+    }
+
+    @Get()
+    @Mount('extract')
+    public extract(): ActiveStatus {
+        return 'active';
+    }
+
+    @Get()
+    @Mount('exclude')
+    public exclude(): NonDeletedStatus {
+        return 'active';
+    }
+
+    @Get()
+    @Mount('return-type')
+    public returnType(): FooReturn {
+        return { bar: 'a', baz: 'b' };
+    }
+
+    @Get()
+    @Mount('awaited')
+    public awaited(): AwaitedFoo {
+        return { bar: 'a', baz: 'b' };
+    }
+
+    @Get()
+    @Mount('awaited-nested')
+    public awaitedNested(): AwaitedNested {
+        return { bar: 'a', baz: 'b' };
+    }
+
+    @Get()
+    @Mount('instance-type')
+    public instanceType(): FooInstance {
+        return new FooFactory('test', 1);
     }
 }

--- a/packages/decorators/test/data/controllers/utility-types.ts
+++ b/packages/decorators/test/data/controllers/utility-types.ts
@@ -29,7 +29,6 @@ function createFoo(): Foo {
     return { bar: 'a', baz: 'b' };
 }
 type FooReturn = ReturnType<typeof createFoo>;
-
 type FooParams = Parameters<typeof createFoo>;
 
 type AwaitedFoo = Awaited<Promise<Foo>>;
@@ -96,5 +95,17 @@ export class UtilityTypes {
     @Mount('instance-type')
     public instanceType(): FooInstance {
         return new FooFactory('test', 1);
+    }
+
+    @Get()
+    @Mount('parameters')
+    public parameters(): FooParams {
+        return [] as unknown as FooParams;
+    }
+
+    @Get()
+    @Mount('constructor-parameters')
+    public constructorParameters(): FooCtorParams {
+        return ['test', 1];
     }
 }

--- a/packages/metadata/src/resolver/constants.ts
+++ b/packages/metadata/src/resolver/constants.ts
@@ -41,4 +41,12 @@ export enum UtilityTypeName {
     RECORD = 'Record',
     REQUIRED = 'Required',
     PICK = 'Pick',
+    // Checker-resolvable utility types — delegated to the TS type checker
+    EXTRACT = 'Extract',
+    EXCLUDE = 'Exclude',
+    RETURN_TYPE = 'ReturnType',
+    PARAMETERS = 'Parameters',
+    AWAITED = 'Awaited',
+    INSTANCE_TYPE = 'InstanceType',
+    CONSTRUCTOR_PARAMETERS = 'ConstructorParameters',
 }

--- a/packages/metadata/src/resolver/constants.ts
+++ b/packages/metadata/src/resolver/constants.ts
@@ -31,6 +31,7 @@ export enum TypeName {
     NESTED_OBJECT_LITERAL = 'nestedObjectLiteral',
     UNION = 'union',
     INTERSECTION = 'intersection',
+    TUPLE = 'tuple',
 }
 
 export enum UtilityTypeName {

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -19,7 +19,6 @@ import {
     getJSDocTagComment,
     getJSDocTagNames,
     hasJSDocTag,
-    hasOwnProperty,
 } from '../utils';
 import { ResolverError } from './error';
 import { getNodeExtensions } from './extension';
@@ -38,7 +37,6 @@ import {
 } from './sub';
 import { getLiteralValue } from './sub/literal';
 import {
-    isNestedObjectLiteralType,
     isRefAliasType,
     isRefObjectType,
 } from './type-guards';
@@ -55,7 +53,6 @@ import type {
     Type,
     TypeNodeResolverContext,
     UsableDeclaration,
-    UtilityTypeOptions,
 } from './types';
 import { getNodeDescription, toTypeNodeOrFail } from './utils';
 
@@ -148,8 +145,8 @@ export class TypeNodeResolver extends ResolverBase {
                 this.resolveNestedType(typeNode, parentNode, context, referencer)
             ),
             propertyFromSignature: (sig, overrideToken) => this.propertyFromSignature(sig, overrideToken),
-            propertyFromDeclaration: (decl, overrideToken, utilityType) => (
-                this.propertyFromDeclaration(decl, overrideToken, utilityType)
+            propertyFromDeclaration: (decl, overrideToken) => (
+                this.propertyFromDeclaration(decl, overrideToken)
             ),
             getNodeDescription: (node) => this.getNodeDescription(node),
             getNodeExample: (node) => this.getNodeExample(node),
@@ -350,6 +347,10 @@ export class TypeNodeResolver extends ResolverBase {
                     this.context,
                 );
             }
+
+            if (TypeNodeResolver.isCheckerResolvableUtilityType(typeReference.typeName.text)) {
+                return this.resolveUtilityTypeViaChecker(typeReference);
+            }
         }
 
         const referenceType = this.getReferenceType(typeReference);
@@ -361,81 +362,44 @@ export class TypeNodeResolver extends ResolverBase {
     // ------------------------------------------------------------------------
     // Utility Type(s)
     // ------------------------------------------------------------------------
-    private static toUtilityType(
-        typeName: string | ts.Identifier | undefined,
-    ) : undefined | `${UtilityTypeName}` {
-        if (typeof typeName === 'undefined') {
-            return undefined;
-        }
 
-        const values : string[] = Object.values(UtilityTypeName);
-        const index = values.indexOf(typeof typeName !== 'string' ? typeName.text : typeName);
-        if (index === -1) {
-            return undefined;
-        }
+    private static readonly CHECKER_RESOLVABLE_UTILITY_TYPES: ReadonlySet<string> = new Set([
+        UtilityTypeName.NON_NULLABLE,
+        UtilityTypeName.OMIT,
+        UtilityTypeName.PARTIAL,
+        UtilityTypeName.READONLY,
+        UtilityTypeName.REQUIRED,
+        UtilityTypeName.PICK,
+        UtilityTypeName.EXTRACT,
+        UtilityTypeName.EXCLUDE,
+        UtilityTypeName.RETURN_TYPE,
+        UtilityTypeName.PARAMETERS,
+        UtilityTypeName.AWAITED,
+        UtilityTypeName.INSTANCE_TYPE,
+        UtilityTypeName.CONSTRUCTOR_PARAMETERS,
+    ]);
 
-        return values[index] as UtilityTypeName;
+    private static isCheckerResolvableUtilityType(name: string): boolean {
+        return TypeNodeResolver.CHECKER_RESOLVABLE_UTILITY_TYPES.has(name);
     }
 
-    private static getUtilityTypeOptions(typeArguments: ts.NodeArray<ts.TypeNode>) {
-        const utilityOptions : UtilityTypeOptions = { keys: [] };
+    private resolveUtilityTypeViaChecker(typeReference: ts.TypeReferenceNode): Type {
+        const type = this.current.typeChecker.getTypeFromTypeNode(typeReference);
+        // InTypeAlias prevents the node builder from emitting type alias
+        // references (which could cause circular resolution when the utility
+        // type is used inside a type alias declaration).
+        const resolvedTypeNode = toTypeNodeOrFail(
+            this.current.typeChecker,
+            type,
+            undefined,
+            ts.NodeBuilderFlags.NoTruncation | ts.NodeBuilderFlags.InTypeAlias,
+        );
 
-        if (typeArguments.length >= 2) {
-            if (ts.isUnionTypeNode(typeArguments[1])) {
-                const args : ts.NodeArray<ts.TypeNode> = (typeArguments[1] as ts.UnionTypeNode).types;
-                for (const arg of args) {
-                    if (ts.isLiteralTypeNode(arg)) {
-                        utilityOptions.keys.push(getLiteralValue(arg as ts.LiteralTypeNode));
-                    }
-                }
-            }
-
-            if (ts.isLiteralTypeNode(typeArguments[1])) {
-                utilityOptions.keys.push(getLiteralValue(typeArguments[1] as ts.LiteralTypeNode));
-            }
-        }
-
-        return utilityOptions;
-    }
-
-    private filterUtilityProperties<T extends Record<'name' | string, any>>(
-        properties: T[],
-        utilityType?: `${UtilityTypeName}`,
-        utilityOptions?: UtilityTypeOptions,
-    ) : T[] {
-        if (typeof utilityType === 'undefined' || typeof utilityOptions === 'undefined') {
-            return properties;
-        }
-
-        return properties
-            .filter((property) => {
-                const name : string = typeof property.name !== 'string' ? (property.name as ts.Identifier).text : property.name;
-
-                switch (utilityType) {
-                    case UtilityTypeName.PICK:
-                        return utilityOptions.keys.includes(name);
-                    case UtilityTypeName.OMIT:
-                        return !utilityOptions.keys.includes(name);
-                }
-
-                return true;
-            })
-            .map((property) => {
-                if (hasOwnProperty(property, 'required')) {
-                    const prop = property as T & { required: boolean };
-                    switch (utilityType) {
-                        case UtilityTypeName.PARTIAL:
-                            prop.required = false;
-                            break;
-                        case UtilityTypeName.REQUIRED:
-                        case UtilityTypeName.NON_NULLABLE:
-                            prop.required = true;
-                            break;
-                    }
-                }
-
-                return property;
-            });
+        return this.resolveNestedType(
+            resolvedTypeNode,
+            this.parentNode,
+            this.context,
+        );
     }
 
     private static resolveSpecialReference(node: ts.Identifier) : Type | undefined {
@@ -536,30 +500,7 @@ export class TypeNodeResolver extends ResolverBase {
 
         const name = this.contextualizedName(resolvableName);
 
-        // Handle Utility Types
-        const identifierName = (type as ts.Identifier).text;
-
-        const utilityType = TypeNodeResolver.toUtilityType(identifierName);
-        let utilityTypeOptions : UtilityTypeOptions | undefined;
-
-        if (utilityType) {
-            const { typeArguments } = type.parent as ts.TypeReferenceNode;
-            if (typeArguments) {
-                if (ts.isTypeReferenceNode(typeArguments[0])) {
-                    type = (typeArguments[0] as ts.TypeReferenceNode).typeName;
-                } else if (ts.isExpressionWithTypeArguments(typeArguments[0])) {
-                    type = (typeArguments[0] as ts.ExpressionWithTypeArguments).expression as ts.EntityName;
-                } else {
-                    throw new ResolverError('Can\'t resolve Reference type.');
-                }
-
-                utilityTypeOptions = TypeNodeResolver.getUtilityTypeOptions(typeArguments);
-            } else {
-                throw new ResolverError('Can\'t resolve type arguments of utility type.');
-            }
-        } else {
-            this.typeArgumentsToContext(node, type, this.context);
-        }
+        this.typeArgumentsToContext(node, type, this.context);
 
         try {
             const existingType = this.current.resolverCache.getCachedType(name);
@@ -574,7 +515,7 @@ export class TypeNodeResolver extends ResolverBase {
             this.current.resolverCache.markInProgress(name);
 
             try {
-                const refName = TypeNodeResolver.getRefTypeName(name, utilityType);
+                const refName = TypeNodeResolver.getRefTypeName(name);
                 const declarations = this.getModelTypeDeclarations(type);
                 const referenceTypes: ReferenceType[] = [];
                 for (const declaration of declarations) {
@@ -584,8 +525,6 @@ export class TypeNodeResolver extends ResolverBase {
                                 declaration,
                                 name,
                                 node,
-                                utilityType,
-                                utilityTypeOptions,
                             ),
                         );
                     } else if (isEnumDeclaration(declaration)) {
@@ -598,8 +537,6 @@ export class TypeNodeResolver extends ResolverBase {
                             this.getModelReference(
                                 declaration as ts.InterfaceDeclaration,
                                 name,
-                                utilityType,
-                                utilityTypeOptions,
                             ),
                         );
                     }
@@ -625,20 +562,19 @@ export class TypeNodeResolver extends ResolverBase {
         declaration: ts.TypeAliasDeclaration,
         name: string,
         referencer: ts.TypeReferenceType,
-        utilityType?: `${UtilityTypeName}`,
-        utilityTypeOptions?: UtilityTypeOptions,
     ): ReferenceType {
-        const refName = TypeNodeResolver.getRefTypeName(name, utilityType);
+        const refName = TypeNodeResolver.getRefTypeName(name);
 
         if (declaration.type.kind === ts.SyntaxKind.TypeReference) {
             const innerRef = declaration.type as ts.TypeReferenceNode;
-            // Record<K,V> should not go through getReferenceType because its
-            // first type argument is a key type (string/number), not a model reference.
-            // resolveNestedType handles it correctly via resolveTypeReference.
-            const isRecord = ts.isIdentifier(innerRef.typeName) &&
-                innerRef.typeName.text === UtilityTypeName.RECORD;
+            // Record<K,V> and checker-resolvable utility types (Pick, Omit, etc.)
+            // should not go through getReferenceType — resolveNestedType handles
+            // them correctly via resolveTypeReference.
+            const innerName = ts.isIdentifier(innerRef.typeName) ? innerRef.typeName.text : undefined;
+            const skipReferenceType = innerName === UtilityTypeName.RECORD ||
+                (innerName !== undefined && TypeNodeResolver.isCheckerResolvableUtilityType(innerName));
 
-            if (!isRecord) {
+            if (!skipReferenceType) {
                 const referenceType = this.getReferenceType(innerRef);
                 if (referenceType.refName === refName) {
                     return referenceType;
@@ -652,10 +588,6 @@ export class TypeNodeResolver extends ResolverBase {
             this.context,
             this.referencer || referencer,
         );
-
-        if (isNestedObjectLiteralType(type)) {
-            type.properties = this.filterUtilityProperties(type.properties, utilityType, utilityTypeOptions);
-        }
 
         const example = this.getNodeExample(declaration);
 
@@ -675,8 +607,6 @@ export class TypeNodeResolver extends ResolverBase {
     private getModelReference(
         modelType: ts.InterfaceDeclaration | ts.ClassDeclaration,
         name: string,
-        utilityType?: `${UtilityTypeName}`,
-        utilityOptions?: UtilityTypeOptions,
     ) : ReferenceType {
         const example = this.getNodeExample(modelType);
         const description = this.getNodeDescription(modelType);
@@ -715,7 +645,7 @@ export class TypeNodeResolver extends ResolverBase {
             }
 
             return {
-                refName: `${TypeNodeResolver.getRefTypeName(name, utilityType)}Alias`,
+                refName: `${TypeNodeResolver.getRefTypeName(name)}Alias`,
                 typeName: TypeName.REF_ALIAS,
                 description,
                 type: this.resolveNestedType(nodeType),
@@ -725,7 +655,7 @@ export class TypeNodeResolver extends ResolverBase {
             };
         }
 
-        const properties = this.getModelProperties(modelType, undefined, utilityType, utilityOptions);
+        const properties = this.getModelProperties(modelType);
         const additionalProperties = this.getModelAdditionalProperties(modelType);
         const inheritedProperties = this.getModelInheritedProperties(modelType) || [];
 
@@ -733,8 +663,8 @@ export class TypeNodeResolver extends ResolverBase {
             additionalProperties,
             typeName: TypeName.REF_OBJECT,
             description,
-            properties: this.filterUtilityProperties(inheritedProperties, utilityType, utilityOptions),
-            refName: TypeNodeResolver.getRefTypeName(name, utilityType),
+            properties: inheritedProperties,
+            refName: TypeNodeResolver.getRefTypeName(name),
             deprecated,
             ...(example && { example }),
         };
@@ -744,9 +674,7 @@ export class TypeNodeResolver extends ResolverBase {
         return referenceType;
     }
 
-    private static getRefTypeName(name: string, utilityType?: `${UtilityTypeName}`): string {
-        const isUtility = typeof utilityType !== 'undefined';
-
+    private static getRefTypeName(name: string): string {
         const sanitized = name
             // Structural characters → temporary placeholders
             .replace(/[<>]/g, '_')
@@ -756,8 +684,8 @@ export class TypeNodeResolver extends ResolverBase {
             .replace(/,/g, '.')
             .replace(/'([^']*)'/g, '$1')
             .replace(/"([^"]*)"/g, '$1')
-            .replace(/&/g, isUtility ? '--and--' : '-and-')
-            .replace(/\|/g, isUtility ? '--or--' : '-or-')
+            .replace(/&/g, '-and-')
+            .replace(/\|/g, '-or-')
             .replace(/\[\]/g, '-array')
             .replace(/([a-z]+):([a-z]+)/gi, '$1-$2')
             .replace(/;/g, '--')
@@ -965,8 +893,6 @@ export class TypeNodeResolver extends ResolverBase {
     private getModelProperties(
         node: ts.InterfaceDeclaration | ts.ClassDeclaration,
         overrideToken?: OverrideToken,
-        utilityType?: `${UtilityTypeName}`,
-        utilityOptions?: UtilityTypeOptions,
     ) : ResolverProperty[] {
         const isIgnored = (e: ts.TypeElement | ts.ClassElement) => hasJSDocTag(e, JSDocTagName.IGNORE);
 
@@ -982,7 +908,7 @@ export class TypeNodeResolver extends ResolverBase {
         }
 
         // Class model
-        let properties = node.members
+        const properties = node.members
             .filter((member) => !isIgnored(member) &&
                     member.kind === ts.SyntaxKind.PropertyDeclaration &&
                 !this.hasStaticModifier(member) &&
@@ -998,9 +924,7 @@ export class TypeNodeResolver extends ResolverBase {
             properties.push(...constructorProperties);
         }
 
-        properties = this.filterUtilityProperties(properties, utilityType, utilityOptions);
-
-        return properties.map((property) => this.propertyFromDeclaration(property, overrideToken, utilityType));
+        return properties.map((property) => this.propertyFromDeclaration(property, overrideToken));
     }
 
     private propertyFromSignature(propertySignature: ts.PropertySignature, overrideToken?: OverrideToken) {
@@ -1040,7 +964,6 @@ export class TypeNodeResolver extends ResolverBase {
     private propertyFromDeclaration(
         propertyDeclaration: ts.PropertyDeclaration | ts.ParameterDeclaration,
         overrideToken?: OverrideToken,
-        utilityType?: string,
     ) {
         const identifier = propertyDeclaration.name as ts.Identifier;
         let typeNode = propertyDeclaration.type;
@@ -1061,16 +984,6 @@ export class TypeNodeResolver extends ResolverBase {
             required = true;
         } else if (overrideToken && overrideToken.kind === ts.SyntaxKind.QuestionToken) {
             required = false;
-        }
-
-        if (typeof utilityType !== 'undefined') {
-            if (utilityType === 'Partial') {
-                required = false;
-            }
-
-            if (utilityType === 'Required') {
-                required = true;
-            }
         }
 
         const property: ResolverProperty = {

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -32,6 +32,7 @@ import {
     resolveLiteralType,
     resolveMappedType,
     resolveObjectLiteralType,
+    resolveTupleType,
     resolveTypeOperatorType,
     resolveUnionType,
 } from './sub';
@@ -121,6 +122,7 @@ export class TypeNodeResolver extends ResolverBase {
             resolveUnionType(this.typeNode, ctx) ??
             resolveIntersectionType(this.typeNode, ctx) ??
             resolveObjectLiteralType(this.typeNode, ctx) ??
+            resolveTupleType(this.typeNode, ctx) ??
             resolveMappedType(this.typeNode, ctx) ??
             this.resolveConditionalType() ??
             resolveTypeOperatorType(this.typeNode, ctx) ??
@@ -388,12 +390,18 @@ export class TypeNodeResolver extends ResolverBase {
         // InTypeAlias prevents the node builder from emitting type alias
         // references (which could cause circular resolution when the utility
         // type is used inside a type alias declaration).
-        const resolvedTypeNode = toTypeNodeOrFail(
-            this.current.typeChecker,
+        const resolvedTypeNode = this.current.typeChecker.typeToTypeNode(
             type,
             undefined,
             ts.NodeBuilderFlags.NoTruncation | ts.NodeBuilderFlags.InTypeAlias,
         );
+
+        // typeToTypeNode returns undefined for some edge cases (e.g. empty
+        // tuples from Parameters<> of a no-arg function). Fall back to an
+        // any-element array which is the closest OpenAPI representation.
+        if (!resolvedTypeNode) {
+            return { typeName: TypeName.ARRAY, elementType: { typeName: TypeName.ANY } };
+        }
 
         return this.resolveNestedType(
             resolvedTypeNode,

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -398,9 +398,9 @@ export class TypeNodeResolver extends ResolverBase {
 
         // typeToTypeNode returns undefined for some edge cases (e.g. empty
         // tuples from Parameters<> of a no-arg function). Fall back to an
-        // any-element array which is the closest OpenAPI representation.
+        // empty tuple type.
         if (!resolvedTypeNode) {
-            return { typeName: TypeName.ARRAY, elementType: { typeName: TypeName.ANY } };
+            return { typeName: TypeName.TUPLE, elements: [] };
         }
 
         return this.resolveNestedType(

--- a/packages/metadata/src/resolver/sub/index.ts
+++ b/packages/metadata/src/resolver/sub/index.ts
@@ -14,5 +14,6 @@ export * from './mapped';
 export * from './object-literal';
 export * from './primitive';
 export * from './reference';
+export * from './tuple';
 export * from './type-operator';
 export * from './union';

--- a/packages/metadata/src/resolver/sub/tuple.ts
+++ b/packages/metadata/src/resolver/sub/tuple.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import * as ts from 'typescript';
+import { TypeName } from '../constants';
+import type { 
+    ArrayType, 
+    SubResolverContext, 
+    Type, 
+    UnionType, 
+} from '../types';
+
+export function resolveTupleType(
+    typeNode: ts.TypeNode,
+    ctx: SubResolverContext,
+): Type | undefined {
+    if (!ts.isTupleTypeNode(typeNode)) {
+        return undefined;
+    }
+
+    const elements = typeNode.elements.map((element) => {
+        // Named tuple members (e.g. [name: string, count: number]) wrap the actual type
+        const actualType = ts.isNamedTupleMember(element) ? element.type : element;
+        return ctx.resolveType(actualType, ctx.parentNode, ctx.context);
+    });
+
+    if (elements.length === 0) {
+        return {
+            typeName: TypeName.ARRAY,
+            elementType: { typeName: TypeName.ANY },
+        } as ArrayType;
+    }
+
+    if (elements.length === 1) {
+        return {
+            typeName: TypeName.ARRAY,
+            elementType: elements[0],
+        } as ArrayType;
+    }
+
+    // Multiple element types → array with union element type
+    return {
+        typeName: TypeName.ARRAY,
+        elementType: {
+            typeName: TypeName.UNION,
+            members: elements,
+        } as UnionType,
+    } as ArrayType;
+}

--- a/packages/metadata/src/resolver/sub/tuple.ts
+++ b/packages/metadata/src/resolver/sub/tuple.ts
@@ -7,11 +7,10 @@
 
 import * as ts from 'typescript';
 import { TypeName } from '../constants';
-import type { 
-    ArrayType, 
-    SubResolverContext, 
-    Type, 
-    UnionType, 
+import type {
+    SubResolverContext,
+    TupleType,
+    Type,
 } from '../types';
 
 export function resolveTupleType(
@@ -23,31 +22,16 @@ export function resolveTupleType(
     }
 
     const elements = typeNode.elements.map((element) => {
-        // Named tuple members (e.g. [name: string, count: number]) wrap the actual type
-        const actualType = ts.isNamedTupleMember(element) ? element.type : element;
-        return ctx.resolveType(actualType, ctx.parentNode, ctx.context);
+        const isNamed = ts.isNamedTupleMember(element);
+        const actualType = isNamed ? element.type : element;
+        return {
+            type: ctx.resolveType(actualType, ctx.parentNode, ctx.context),
+            ...(isNamed && { name: element.name.text }),
+        };
     });
 
-    if (elements.length === 0) {
-        return {
-            typeName: TypeName.ARRAY,
-            elementType: { typeName: TypeName.ANY },
-        } as ArrayType;
-    }
-
-    if (elements.length === 1) {
-        return {
-            typeName: TypeName.ARRAY,
-            elementType: elements[0],
-        } as ArrayType;
-    }
-
-    // Multiple element types → array with union element type
     return {
-        typeName: TypeName.ARRAY,
-        elementType: {
-            typeName: TypeName.UNION,
-            members: elements,
-        } as UnionType,
-    } as ArrayType;
+        typeName: TypeName.TUPLE,
+        elements,
+    } as TupleType;
 }

--- a/packages/metadata/src/resolver/type-guards.ts
+++ b/packages/metadata/src/resolver/type-guards.ts
@@ -32,6 +32,7 @@ import type {
     RefObjectType,
     ReferenceType,
     StringType,
+    TupleType,
     UndefinedType,
     UnionType,
     VoidType,
@@ -135,6 +136,10 @@ export function isIntersectionType(param: BaseType): param is IntersectionType {
 
 export function isUnionType(param: BaseType): param is UnionType {
     return param.typeName === TypeName.UNION;
+}
+
+export function isTupleType(param: BaseType): param is TupleType {
+    return param.typeName === TypeName.TUPLE;
 }
 
 // -------------------------------------------

--- a/packages/metadata/src/resolver/types.ts
+++ b/packages/metadata/src/resolver/types.ts
@@ -29,6 +29,7 @@ export type Type = PrimitiveType |
         NestedObjectLiteralType |
         UnionType |
         IntersectionType |
+        TupleType |
         VoidType;
 
 // -------------------------------------------
@@ -141,6 +142,16 @@ export interface IntersectionType extends BaseType {
 export interface UnionType extends BaseType {
     typeName: `${TypeName.UNION}`;
     members: Type[];
+}
+
+export type TupleElement = {
+    type: Type;
+    name?: string;
+};
+
+export interface TupleType extends BaseType {
+    typeName: `${TypeName.TUPLE}`;
+    elements: TupleElement[];
 }
 
 // -------------------------------------------

--- a/packages/metadata/src/resolver/types.ts
+++ b/packages/metadata/src/resolver/types.ts
@@ -218,10 +218,6 @@ export interface IResolverCache {
     clear(): void;
 }
 
-export type UtilityTypeOptions = {
-    keys: Array<string | number | boolean | null>;
-};
-
 // -------------------------------------------
 // Resolver Internal Types
 // -------------------------------------------
@@ -265,7 +261,6 @@ export type SubResolverContext = {
     propertyFromDeclaration(
         decl: ts.PropertyDeclaration | ts.ParameterDeclaration,
         overrideToken?: OverrideToken,
-        utilityType?: string,
     ): ResolverProperty;
 
     getNodeDescription(

--- a/packages/metadata/test/unit/generator/complex-types.spec.ts
+++ b/packages/metadata/test/unit/generator/complex-types.spec.ts
@@ -105,11 +105,15 @@ describe('complex type metadata extraction', () => {
         });
 
         it('should resolve nested generic GenericWrapper<GenericWrapper<string>>', () => {
-            expect(metadata.referenceTypes).toHaveProperty('NestedGeneric');
             const nestedGeneric = metadata.referenceTypes.NestedGeneric;
             expect(nestedGeneric).toBeDefined();
-            // Should be a refAlias or refObject with resolved inner types
-            expect(['refAlias', 'refObject']).toContain(nestedGeneric.typeName);
+            expect(nestedGeneric.typeName).toEqual('refAlias');
+            const alias = nestedGeneric as RefAliasType;
+            expect(alias.type.typeName).toEqual('refObject');
+            const obj = alias.type as RefObjectType;
+            const propNames = obj.properties.map((p) => p.name);
+            expect(propNames).toContain('data');
+            expect(propNames).toContain('meta');
         });
     });
 
@@ -117,22 +121,16 @@ describe('complex type metadata extraction', () => {
         it('should resolve TimestampedPerson as intersection', () => {
             const tp = metadata.referenceTypes.TimestampedPerson;
             expect(tp).toBeDefined();
-            // Could be refAlias wrapping an intersection, or a resolved refObject
-            if (tp.typeName === 'refAlias') {
-                const alias = tp as RefAliasType;
-                expect(alias.type.typeName).toEqual('intersection');
-                const intersection = alias.type as IntersectionType;
-                expect(intersection.members.length).toEqual(2);
-            } else if (tp.typeName === 'refObject') {
-                // Flattened — should have properties from both Person and Timestamped
-                const obj = tp as RefObjectType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('name');
-                expect(propNames).toContain('createdAt');
-                expect(propNames).toContain('updatedAt');
-            } else {
-                expect.unreachable(`Unexpected TimestampedPerson type: ${tp.typeName}`);
-            }
+            expect(tp.typeName).toEqual('refAlias');
+            const alias = tp as RefAliasType;
+            expect(alias.type.typeName).toEqual('intersection');
+            const intersection = alias.type as IntersectionType;
+            expect(intersection.members).toHaveLength(2);
+            // First member: Person, second: Timestamped
+            expect(intersection.members[0].typeName).toEqual('refObject');
+            expect((intersection.members[0] as RefObjectType).refName).toEqual('Person');
+            expect(intersection.members[1].typeName).toEqual('refObject');
+            expect((intersection.members[1] as RefObjectType).refName).toEqual('Timestamped');
         });
     });
 
@@ -170,27 +168,17 @@ describe('complex type metadata extraction', () => {
     });
 
     describe('utility types', () => {
-        it('should resolve PartialPerson', () => {
+        it('should resolve PartialPerson with all properties optional', () => {
             const pp = metadata.referenceTypes.PartialPerson;
             expect(pp).toBeDefined();
-            // Partial<Person> may resolve as refAlias (nestedObjectLiteral) or refObject
-            expect(['refAlias', 'refObject']).toContain(pp.typeName);
-
-            if (pp.typeName === 'refAlias') {
-                const alias = pp as RefAliasType;
-                expect(alias.type.typeName).toEqual('nestedObjectLiteral');
-                const obj = alias.type as NestedObjectLiteralType;
-                expect(obj.properties.length).toBeGreaterThan(0);
-                for (const prop of obj.properties) {
-                    expect(prop.required).toBe(false);
-                }
-            } else {
-                // refObject — verify it has properties from Person
-                const obj = pp as RefObjectType;
-                expect(obj.properties.length).toBeGreaterThan(0);
-                // Note: Partial<T> should make all properties optional,
-                // but the resolver currently preserves original required flags.
-                // This is a known limitation tracked for future improvement.
+            expect(pp.typeName).toEqual('refAlias');
+            const alias = pp as RefAliasType;
+            expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = alias.type as NestedObjectLiteralType;
+            const propNames = obj.properties.map((p) => p.name).sort();
+            expect(propNames).toEqual(['address', 'name']);
+            for (const prop of obj.properties) {
+                expect(prop.required).toBe(false);
             }
         });
 

--- a/packages/metadata/test/unit/generator/metadata.spec.ts
+++ b/packages/metadata/test/unit/generator/metadata.spec.ts
@@ -38,56 +38,37 @@ describe('src/generator/metadata', () => {
     });
 
     it('should have utility-types controller', () => {
-        let index = metadata.controllers.findIndex(
-            (controller) => controller.name === 'UtilityTypes',
-        );
-        expect(index).toBeGreaterThanOrEqual(0);
-
-        const controller = metadata.controllers[index];
-
-        // Helper to walk through refAlias layers to find nestedObjectLiteral
-        function findObjectLiteral(type: any): NestedObjectLiteralType | undefined {
-            if (type.typeName === 'nestedObjectLiteral') return type;
-            if (type.typeName === 'refAlias') return findObjectLiteral((type as RefAliasType).type);
-            return undefined;
-        }
+        const controller = metadata.controllers.find(
+            (c) => c.name === 'UtilityTypes',
+        )!;
+        expect(controller).toBeDefined();
 
         // pick
-        index = controller.methods.findIndex(
-            (method) => method.name === 'pick',
-        );
-        expect(index).toBeGreaterThanOrEqual(0);
-
-        let method = controller.methods[index];
-        expect(method.name).toEqual('pick');
-        let nestedObjectLiteral = findObjectLiteral(method.type);
-        expect(nestedObjectLiteral).toBeDefined();
-        expect(nestedObjectLiteral!.properties.length).toEqual(1);
-        let property = nestedObjectLiteral!.properties[0];
-        expect(property.name).toEqual('bar');
+        const pick = controller.methods.find((m) => m.name === 'pick')!;
+        expect(pick).toBeDefined();
+        expect(pick.type.typeName).toEqual('refAlias');
+        const pickAlias = pick.type as RefAliasType;
+        expect(pickAlias.type.typeName).toEqual('nestedObjectLiteral');
+        const pickObj = pickAlias.type as NestedObjectLiteralType;
+        expect(pickObj.properties).toHaveLength(1);
+        expect(pickObj.properties[0].name).toEqual('bar');
 
         // omit
-        index = controller.methods.findIndex(
-            (method) => method.name === 'omit',
-        );
-        expect(index).toBeGreaterThanOrEqual(0);
-
-        method = controller.methods[index];
-        expect(method.name).toEqual('omit');
-        nestedObjectLiteral = findObjectLiteral(method.type);
-        expect(nestedObjectLiteral).toBeDefined();
-        expect(nestedObjectLiteral!.properties.length).toEqual(1);
-        property = nestedObjectLiteral!.properties[0];
-        expect(property.name).toEqual('baz');
+        const omit = controller.methods.find((m) => m.name === 'omit')!;
+        expect(omit).toBeDefined();
+        expect(omit.type.typeName).toEqual('refAlias');
+        const omitAlias = omit.type as RefAliasType;
+        expect(omitAlias.type.typeName).toEqual('nestedObjectLiteral');
+        const omitObj = omitAlias.type as NestedObjectLiteralType;
+        expect(omitObj.properties).toHaveLength(1);
+        expect(omitObj.properties[0].name).toEqual('baz');
 
         // partial
-        index = controller.methods.findIndex(
-            (method) => method.name === 'partial',
-        );
-        expect(index).toBeGreaterThanOrEqual(0);
-
-        method = controller.methods[index];
-        expect(method.name).toEqual('partial');
+        const partial = controller.methods.find((m) => m.name === 'partial')!;
+        expect(partial).toBeDefined();
+        expect(partial.type.typeName).toEqual('refAlias');
+        const partialAlias = partial.type as RefAliasType;
+        expect(partialAlias.type.typeName).toEqual('nestedObjectLiteral');
     });
 
     it('should generate metadata', async () => {

--- a/packages/metadata/test/unit/generator/metadata.spec.ts
+++ b/packages/metadata/test/unit/generator/metadata.spec.ts
@@ -45,6 +45,13 @@ describe('src/generator/metadata', () => {
 
         const controller = metadata.controllers[index];
 
+        // Helper to walk through refAlias layers to find nestedObjectLiteral
+        function findObjectLiteral(type: any): NestedObjectLiteralType | undefined {
+            if (type.typeName === 'nestedObjectLiteral') return type;
+            if (type.typeName === 'refAlias') return findObjectLiteral((type as RefAliasType).type);
+            return undefined;
+        }
+
         // pick
         index = controller.methods.findIndex(
             (method) => method.name === 'pick',
@@ -53,10 +60,10 @@ describe('src/generator/metadata', () => {
 
         let method = controller.methods[index];
         expect(method.name).toEqual('pick');
-        let refAlias = ((method.type as RefAliasType).type as RefAliasType);
-        let nestedObjectLiteral = (refAlias.type as NestedObjectLiteralType);
-        expect(nestedObjectLiteral.properties.length).toEqual(1);
-        let property = nestedObjectLiteral.properties.pop();
+        let nestedObjectLiteral = findObjectLiteral(method.type);
+        expect(nestedObjectLiteral).toBeDefined();
+        expect(nestedObjectLiteral!.properties.length).toEqual(1);
+        let property = nestedObjectLiteral!.properties[0];
         expect(property.name).toEqual('bar');
 
         // omit
@@ -67,14 +74,13 @@ describe('src/generator/metadata', () => {
 
         method = controller.methods[index];
         expect(method.name).toEqual('omit');
-        refAlias = ((method.type as RefAliasType).type as RefAliasType);
-        nestedObjectLiteral = (refAlias.type as NestedObjectLiteralType);
-        expect(nestedObjectLiteral.properties.length).toEqual(1);
-        property = nestedObjectLiteral.properties.pop();
+        nestedObjectLiteral = findObjectLiteral(method.type);
+        expect(nestedObjectLiteral).toBeDefined();
+        expect(nestedObjectLiteral!.properties.length).toEqual(1);
+        property = nestedObjectLiteral!.properties[0];
         expect(property.name).toEqual('baz');
 
-        // record
-
+        // partial
         index = controller.methods.findIndex(
             (method) => method.name === 'partial',
         );

--- a/packages/metadata/test/unit/generator/utility-types.spec.ts
+++ b/packages/metadata/test/unit/generator/utility-types.spec.ts
@@ -14,6 +14,7 @@ import {
 import path from 'node:path';
 import process from 'node:process';
 import type {
+    ArrayType,
     Metadata,
     NestedObjectLiteralType,
     RefAliasType,
@@ -36,217 +37,132 @@ describe('utility type metadata extraction', () => {
         });
     });
 
-    function getProperties(type: any): { name: string }[] {
-        if (type.typeName === 'refObject') {
-            return (type as RefObjectType).properties;
-        }
-        if (type.typeName === 'refAlias') {
-            return getProperties((type as RefAliasType).type);
-        }
-        if (type.typeName === 'nestedObjectLiteral') {
-            return (type as NestedObjectLiteralType).properties;
-        }
-        return [];
+    function getMethod(methodName: string) {
+        const controller = metadata.controllers.find(
+            (c) => c.name === 'UtilityTypes',
+        )!;
+        const method = controller.methods.find((m) => m.name === methodName)!;
+        expect(method).toBeDefined();
+        return method;
     }
 
-    function resolveRefType(type: any): any {
-        if (type.typeName === 'refAlias' || type.typeName === 'refObject' || type.typeName === 'refEnum') {
-            const resolved = metadata.referenceTypes[type.refName];
-            return resolved || type;
-        }
-        return type;
+    function expectRefAlias(method: { type: any }, refName: string): RefAliasType {
+        expect(method.type.typeName).toEqual('refAlias');
+        const alias = method.type as RefAliasType;
+        expect(alias.refName).toEqual(refName);
+        return alias;
+    }
+
+    function expectNestedObjectProps(type: any, expectedProps: string[]) {
+        expect(type.typeName).toEqual('nestedObjectLiteral');
+        const obj = type as NestedObjectLiteralType;
+        const propNames = obj.properties.map((p) => p.name).sort();
+        expect(propNames).toEqual(expectedProps.sort());
     }
 
     describe('existing utility types', () => {
-        it('should resolve Pick<Foo, "bar">', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'pick')!;
-            expect(method).toBeDefined();
-
-            const resolved = resolveRefType(method.type);
-            const propNames = getProperties(resolved).map((p) => p.name);
-            expect(propNames).toContain('bar');
-            expect(propNames).not.toContain('baz');
+        it('should resolve Pick<Foo, "bar"> to only bar property', () => {
+            const method = getMethod('pick');
+            const alias = expectRefAlias(method, 'FooBar');
+            expectNestedObjectProps(alias.type, ['bar']);
         });
 
-        it('should resolve Omit<Foo, "bar">', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'omit')!;
-            expect(method).toBeDefined();
-
-            const resolved = resolveRefType(method.type);
-            const propNames = getProperties(resolved).map((p) => p.name);
-            expect(propNames).toContain('baz');
-            expect(propNames).not.toContain('bar');
+        it('should resolve Omit<Foo, "bar"> to only baz property', () => {
+            const method = getMethod('omit');
+            const alias = expectRefAlias(method, 'FooBaz');
+            expectNestedObjectProps(alias.type, ['baz']);
         });
 
         it('should resolve Partial<Foo> with all properties optional', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'partial')!;
-            expect(method).toBeDefined();
+            const method = getMethod('partial');
+            const alias = expectRefAlias(method, 'FooPartial');
+            expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = alias.type as NestedObjectLiteralType;
+            const propNames = obj.properties.map((p) => p.name).sort();
+            expect(propNames).toEqual(['bar', 'baz']);
+            for (const prop of obj.properties) {
+                expect(prop.required).toEqual(false);
+            }
         });
     });
 
     describe('Extract and Exclude', () => {
-        function findUnionMembers(type: any): any[] {
-            // Walk through refAlias wrappers to find the union
-            if (type.typeName === 'refAlias') {
-                return findUnionMembers((type as RefAliasType).type);
-            }
-            if (type.typeName === 'union') {
-                return (type as UnionType).members;
-            }
-            return [];
-        }
-
-        it('should resolve Extract<Status, "active" | "inactive"> to two members', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'extract')!;
-            expect(method).toBeDefined();
-
-            // Extract<Status, 'active' | 'inactive'> = 'active' | 'inactive'
-            const resolved = resolveRefType(method.type);
-            const members = findUnionMembers(resolved);
-            expect(members.length).toEqual(2);
+        it('should resolve Extract<Status, "active" | "inactive"> to two enum members', () => {
+            const method = getMethod('extract');
+            const alias = expectRefAlias(method, 'ActiveStatus');
+            expect(alias.type.typeName).toEqual('union');
+            const union = alias.type as UnionType;
+            expect(union.members).toHaveLength(2);
         });
 
-        it('should resolve Exclude<Status, "deleted"> to two members', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'exclude')!;
-            expect(method).toBeDefined();
-
-            // Exclude<Status, 'deleted'> = 'active' | 'inactive'
-            const resolved = resolveRefType(method.type);
-            const members = findUnionMembers(resolved);
-            expect(members.length).toEqual(2);
+        it('should resolve Exclude<Status, "deleted"> to two enum members', () => {
+            const method = getMethod('exclude');
+            const alias = expectRefAlias(method, 'NonDeletedStatus');
+            expect(alias.type.typeName).toEqual('union');
+            const union = alias.type as UnionType;
+            expect(union.members).toHaveLength(2);
         });
     });
 
     describe('ReturnType', () => {
         it('should resolve ReturnType<typeof createFoo> to Foo shape', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'returnType')!;
-            expect(method).toBeDefined();
-
-            // ReturnType<typeof createFoo> = Foo = { bar: string, baz: string }
-            const { type } = method;
-            if (type.typeName === 'refAlias') {
-                const alias = type as RefAliasType;
-                if (alias.type.typeName === 'nestedObjectLiteral') {
-                    const obj = alias.type as NestedObjectLiteralType;
-                    const propNames = obj.properties.map((p) => p.name);
-                    expect(propNames).toContain('bar');
-                    expect(propNames).toContain('baz');
-                }
-            } else if (type.typeName === 'refObject') {
-                const obj = type as RefObjectType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            } else if (type.typeName === 'nestedObjectLiteral') {
-                const obj = type as NestedObjectLiteralType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            }
+            const method = getMethod('returnType');
+            const alias = expectRefAlias(method, 'FooReturn');
+            expectNestedObjectProps(alias.type, ['bar', 'baz']);
         });
     });
 
     describe('Awaited', () => {
         it('should resolve Awaited<Promise<Foo>> to Foo shape', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'awaited')!;
-            expect(method).toBeDefined();
-
-            // Awaited<Promise<Foo>> = Foo
-            const { type } = method;
-            if (type.typeName === 'refObject') {
-                const obj = type as RefObjectType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            } else if (type.typeName === 'refAlias') {
-                const alias = type as RefAliasType;
-                if (alias.type.typeName === 'nestedObjectLiteral') {
-                    const obj = alias.type as NestedObjectLiteralType;
-                    const propNames = obj.properties.map((p) => p.name);
-                    expect(propNames).toContain('bar');
-                    expect(propNames).toContain('baz');
-                }
-            } else if (type.typeName === 'nestedObjectLiteral') {
-                const obj = type as NestedObjectLiteralType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            }
+            const method = getMethod('awaited');
+            const alias = expectRefAlias(method, 'AwaitedFoo');
+            expectNestedObjectProps(alias.type, ['bar', 'baz']);
         });
 
         it('should resolve Awaited<Promise<Promise<Foo>>> to Foo shape (nested)', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'awaitedNested')!;
-            expect(method).toBeDefined();
+            const method = getMethod('awaitedNested');
+            const alias = expectRefAlias(method, 'AwaitedNested');
+            expectNestedObjectProps(alias.type, ['bar', 'baz']);
+        });
+    });
 
-            // Awaited<Promise<Promise<Foo>>> = Foo
-            const { type } = method;
-            if (type.typeName === 'refObject') {
-                const obj = type as RefObjectType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            } else if (type.typeName === 'refAlias') {
-                const alias = type as RefAliasType;
-                if (alias.type.typeName === 'nestedObjectLiteral') {
-                    const obj = alias.type as NestedObjectLiteralType;
-                    const propNames = obj.properties.map((p) => p.name);
-                    expect(propNames).toContain('bar');
-                    expect(propNames).toContain('baz');
-                }
-            } else if (type.typeName === 'nestedObjectLiteral') {
-                const obj = type as NestedObjectLiteralType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('bar');
-                expect(propNames).toContain('baz');
-            }
+    describe('Parameters', () => {
+        it('should resolve Parameters<typeof createFoo> (no-arg function) to array<any>', () => {
+            const method = getMethod('parameters');
+            const alias = expectRefAlias(method, 'FooParams');
+            expect(alias.type.typeName).toEqual('array');
+            const arr = alias.type as ArrayType;
+            expect(arr.elementType.typeName).toEqual('any');
+        });
+    });
+
+    describe('ConstructorParameters', () => {
+        it('should resolve ConstructorParameters<typeof FooFactory> to array<string | number>', () => {
+            const method = getMethod('constructorParameters');
+            const alias = expectRefAlias(method, 'FooCtorParams');
+            expect(alias.type.typeName).toEqual('array');
+            const arr = alias.type as ArrayType;
+            expect(arr.elementType.typeName).toEqual('union');
+            const union = arr.elementType as UnionType;
+            expect(union.members).toHaveLength(2);
+            const memberTypes = union.members.map((m) => m.typeName).sort();
+            expect(memberTypes).toEqual(['double', 'string']);
         });
     });
 
     describe('InstanceType', () => {
         it('should resolve InstanceType<typeof FooFactory> to FooFactory shape', () => {
-            const controller = metadata.controllers.find(
-                (c) => c.name === 'UtilityTypes',
-            )!;
-            const method = controller.methods.find((m) => m.name === 'instanceType')!;
-            expect(method).toBeDefined();
-
-            // InstanceType<typeof FooFactory> = FooFactory = { name: string, count: number }
-            const { type } = method;
-            if (type.typeName === 'refObject') {
-                const obj = type as RefObjectType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('name');
-                expect(propNames).toContain('count');
-            } else if (type.typeName === 'nestedObjectLiteral') {
-                const obj = type as NestedObjectLiteralType;
-                const propNames = obj.properties.map((p) => p.name);
-                expect(propNames).toContain('name');
-                expect(propNames).toContain('count');
-            }
+            const method = getMethod('instanceType');
+            const alias = expectRefAlias(method, 'FooInstance');
+            expect(alias.type.typeName).toEqual('refObject');
+            const obj = alias.type as RefObjectType;
+            expect(obj.refName).toEqual('FooFactory');
+            const propNames = obj.properties.map((p) => p.name).sort();
+            expect(propNames).toEqual(['count', 'name']);
+            const nameType = obj.properties.find((p) => p.name === 'name')!;
+            expect(nameType.type.typeName).toEqual('string');
+            const countType = obj.properties.find((p) => p.name === 'count')!;
+            expect(countType.type.typeName).toEqual('double');
         });
     });
 });

--- a/packages/metadata/test/unit/generator/utility-types.spec.ts
+++ b/packages/metadata/test/unit/generator/utility-types.spec.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import path from 'node:path';
+import process from 'node:process';
+import type {
+    Metadata,
+    NestedObjectLiteralType,
+    RefAliasType,
+    RefObjectType,
+    UnionType,
+} from '../../../src';
+import { generateMetadata } from '../../../src';
+
+describe('utility type metadata extraction', () => {
+    let metadata: Metadata;
+
+    beforeAll(async () => {
+        metadata = await generateMetadata({
+            entryPoint: [{
+                cwd: path.join(process.cwd(), '..', 'decorators'),
+                pattern: './test/data/controllers/**/*.ts',
+            }],
+            cache: false,
+            preset: '@trapi/decorators',
+        });
+    });
+
+    function getProperties(type: any): { name: string }[] {
+        if (type.typeName === 'refObject') {
+            return (type as RefObjectType).properties;
+        }
+        if (type.typeName === 'refAlias') {
+            return getProperties((type as RefAliasType).type);
+        }
+        if (type.typeName === 'nestedObjectLiteral') {
+            return (type as NestedObjectLiteralType).properties;
+        }
+        return [];
+    }
+
+    function resolveRefType(type: any): any {
+        if (type.typeName === 'refAlias' || type.typeName === 'refObject' || type.typeName === 'refEnum') {
+            const resolved = metadata.referenceTypes[type.refName];
+            return resolved || type;
+        }
+        return type;
+    }
+
+    describe('existing utility types', () => {
+        it('should resolve Pick<Foo, "bar">', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'pick')!;
+            expect(method).toBeDefined();
+
+            const resolved = resolveRefType(method.type);
+            const propNames = getProperties(resolved).map((p) => p.name);
+            expect(propNames).toContain('bar');
+            expect(propNames).not.toContain('baz');
+        });
+
+        it('should resolve Omit<Foo, "bar">', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'omit')!;
+            expect(method).toBeDefined();
+
+            const resolved = resolveRefType(method.type);
+            const propNames = getProperties(resolved).map((p) => p.name);
+            expect(propNames).toContain('baz');
+            expect(propNames).not.toContain('bar');
+        });
+
+        it('should resolve Partial<Foo> with all properties optional', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'partial')!;
+            expect(method).toBeDefined();
+        });
+    });
+
+    describe('Extract and Exclude', () => {
+        function findUnionMembers(type: any): any[] {
+            // Walk through refAlias wrappers to find the union
+            if (type.typeName === 'refAlias') {
+                return findUnionMembers((type as RefAliasType).type);
+            }
+            if (type.typeName === 'union') {
+                return (type as UnionType).members;
+            }
+            return [];
+        }
+
+        it('should resolve Extract<Status, "active" | "inactive"> to two members', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'extract')!;
+            expect(method).toBeDefined();
+
+            // Extract<Status, 'active' | 'inactive'> = 'active' | 'inactive'
+            const resolved = resolveRefType(method.type);
+            const members = findUnionMembers(resolved);
+            expect(members.length).toEqual(2);
+        });
+
+        it('should resolve Exclude<Status, "deleted"> to two members', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'exclude')!;
+            expect(method).toBeDefined();
+
+            // Exclude<Status, 'deleted'> = 'active' | 'inactive'
+            const resolved = resolveRefType(method.type);
+            const members = findUnionMembers(resolved);
+            expect(members.length).toEqual(2);
+        });
+    });
+
+    describe('ReturnType', () => {
+        it('should resolve ReturnType<typeof createFoo> to Foo shape', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'returnType')!;
+            expect(method).toBeDefined();
+
+            // ReturnType<typeof createFoo> = Foo = { bar: string, baz: string }
+            const { type } = method;
+            if (type.typeName === 'refAlias') {
+                const alias = type as RefAliasType;
+                if (alias.type.typeName === 'nestedObjectLiteral') {
+                    const obj = alias.type as NestedObjectLiteralType;
+                    const propNames = obj.properties.map((p) => p.name);
+                    expect(propNames).toContain('bar');
+                    expect(propNames).toContain('baz');
+                }
+            } else if (type.typeName === 'refObject') {
+                const obj = type as RefObjectType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            } else if (type.typeName === 'nestedObjectLiteral') {
+                const obj = type as NestedObjectLiteralType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            }
+        });
+    });
+
+    describe('Awaited', () => {
+        it('should resolve Awaited<Promise<Foo>> to Foo shape', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'awaited')!;
+            expect(method).toBeDefined();
+
+            // Awaited<Promise<Foo>> = Foo
+            const { type } = method;
+            if (type.typeName === 'refObject') {
+                const obj = type as RefObjectType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            } else if (type.typeName === 'refAlias') {
+                const alias = type as RefAliasType;
+                if (alias.type.typeName === 'nestedObjectLiteral') {
+                    const obj = alias.type as NestedObjectLiteralType;
+                    const propNames = obj.properties.map((p) => p.name);
+                    expect(propNames).toContain('bar');
+                    expect(propNames).toContain('baz');
+                }
+            } else if (type.typeName === 'nestedObjectLiteral') {
+                const obj = type as NestedObjectLiteralType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            }
+        });
+
+        it('should resolve Awaited<Promise<Promise<Foo>>> to Foo shape (nested)', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'awaitedNested')!;
+            expect(method).toBeDefined();
+
+            // Awaited<Promise<Promise<Foo>>> = Foo
+            const { type } = method;
+            if (type.typeName === 'refObject') {
+                const obj = type as RefObjectType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            } else if (type.typeName === 'refAlias') {
+                const alias = type as RefAliasType;
+                if (alias.type.typeName === 'nestedObjectLiteral') {
+                    const obj = alias.type as NestedObjectLiteralType;
+                    const propNames = obj.properties.map((p) => p.name);
+                    expect(propNames).toContain('bar');
+                    expect(propNames).toContain('baz');
+                }
+            } else if (type.typeName === 'nestedObjectLiteral') {
+                const obj = type as NestedObjectLiteralType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('bar');
+                expect(propNames).toContain('baz');
+            }
+        });
+    });
+
+    describe('InstanceType', () => {
+        it('should resolve InstanceType<typeof FooFactory> to FooFactory shape', () => {
+            const controller = metadata.controllers.find(
+                (c) => c.name === 'UtilityTypes',
+            )!;
+            const method = controller.methods.find((m) => m.name === 'instanceType')!;
+            expect(method).toBeDefined();
+
+            // InstanceType<typeof FooFactory> = FooFactory = { name: string, count: number }
+            const { type } = method;
+            if (type.typeName === 'refObject') {
+                const obj = type as RefObjectType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('name');
+                expect(propNames).toContain('count');
+            } else if (type.typeName === 'nestedObjectLiteral') {
+                const obj = type as NestedObjectLiteralType;
+                const propNames = obj.properties.map((p) => p.name);
+                expect(propNames).toContain('name');
+                expect(propNames).toContain('count');
+            }
+        });
+    });
+});

--- a/packages/metadata/test/unit/generator/utility-types.spec.ts
+++ b/packages/metadata/test/unit/generator/utility-types.spec.ts
@@ -19,6 +19,7 @@ import type {
     RefAliasType,
     RefObjectType,
     TupleType,
+    UnionType,
 } from '../../../src';
 import { generateMetadata } from '../../../src';
 

--- a/packages/metadata/test/unit/generator/utility-types.spec.ts
+++ b/packages/metadata/test/unit/generator/utility-types.spec.ts
@@ -14,12 +14,11 @@ import {
 import path from 'node:path';
 import process from 'node:process';
 import type {
-    ArrayType,
     Metadata,
     NestedObjectLiteralType,
     RefAliasType,
     RefObjectType,
-    UnionType,
+    TupleType,
 } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -127,26 +126,26 @@ describe('utility type metadata extraction', () => {
     });
 
     describe('Parameters', () => {
-        it('should resolve Parameters<typeof createFoo> (no-arg function) to array<any>', () => {
+        it('should resolve Parameters<typeof createFoo> (no-arg function) to empty tuple', () => {
             const method = getMethod('parameters');
             const alias = expectRefAlias(method, 'FooParams');
-            expect(alias.type.typeName).toEqual('array');
-            const arr = alias.type as ArrayType;
-            expect(arr.elementType.typeName).toEqual('any');
+            expect(alias.type.typeName).toEqual('tuple');
+            const tuple = alias.type as TupleType;
+            expect(tuple.elements).toHaveLength(0);
         });
     });
 
     describe('ConstructorParameters', () => {
-        it('should resolve ConstructorParameters<typeof FooFactory> to array<string | number>', () => {
+        it('should resolve ConstructorParameters<typeof FooFactory> to named tuple [name: string, count: number]', () => {
             const method = getMethod('constructorParameters');
             const alias = expectRefAlias(method, 'FooCtorParams');
-            expect(alias.type.typeName).toEqual('array');
-            const arr = alias.type as ArrayType;
-            expect(arr.elementType.typeName).toEqual('union');
-            const union = arr.elementType as UnionType;
-            expect(union.members).toHaveLength(2);
-            const memberTypes = union.members.map((m) => m.typeName).sort();
-            expect(memberTypes).toEqual(['double', 'string']);
+            expect(alias.type.typeName).toEqual('tuple');
+            const tuple = alias.type as TupleType;
+            expect(tuple.elements).toHaveLength(2);
+            expect(tuple.elements[0].name).toEqual('name');
+            expect(tuple.elements[0].type.typeName).toEqual('string');
+            expect(tuple.elements[1].name).toEqual('count');
+            expect(tuple.elements[1].type.typeName).toEqual('double');
         });
     });
 

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -8,19 +8,20 @@
 import type {
     ArrayType,
     BaseType,
-    EnumType, 
+    EnumType,
     Extension,
     IntersectionType,
     Metadata,
     NestedObjectLiteralType,
     Parameter,
-    ParameterSource, 
+    ParameterSource,
     PrimitiveType,
-    RefAliasType, 
+    RefAliasType,
     RefEnumType,
-    RefObjectType, 
+    RefObjectType,
     ReferenceType,
     ResolverProperty,
+    TupleType,
     UnionType,
     Validators,
     VariableType,
@@ -34,8 +35,9 @@ import {
     isNestedObjectLiteralType,
     isPrimitiveType,
     isReferenceType,
+    isTupleType,
     isUndefinedType,
-    isUnionType, 
+    isUnionType,
     isVoidType,
 } from '@trapi/metadata';
 
@@ -150,6 +152,8 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
             return this.getSchemaForPrimitiveType(type);
         } if (isArrayType(type)) {
             return this.getSchemaForArrayType(type);
+        } if (isTupleType(type)) {
+            return this.getSchemaForTupleType(type);
         } if (isEnumType(type)) {
             return this.getSchemaForEnumType(type);
         } if (isUnionType(type)) {
@@ -211,6 +215,30 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
         return {
             type: DataTypeName.ARRAY,
             items: this.getSchemaForType(arrayType.elementType),
+        };
+    }
+
+    private getSchemaForTupleType(tupleType: TupleType): BaseSchema<Schema> {
+        if (tupleType.elements.length === 0) {
+            return {
+                type: DataTypeName.ARRAY,
+                items: {},
+            };
+        }
+
+        const elementSchemas = tupleType.elements.map((el) => this.getSchemaForType(el.type));
+
+        if (elementSchemas.length === 1) {
+            return {
+                type: DataTypeName.ARRAY,
+                items: elementSchemas[0],
+            };
+        }
+
+        // Multiple elements → array with anyOf items
+        return {
+            type: DataTypeName.ARRAY,
+            items: { anyOf: elementSchemas },
         };
     }
 

--- a/packages/swagger/test/unit/specification/additional-properties.spec.ts
+++ b/packages/swagger/test/unit/specification/additional-properties.spec.ts
@@ -102,14 +102,10 @@ describe('additionalProperties', () => {
             expect(def.additionalProperties).toBeDefined();
         });
 
-        it('should preserve type information in additionalProperties', () => {
+        it('should set additionalProperties to true (V2 limitation)', () => {
             const def = specV2.definitions!.StringMap;
-            if (typeof def.additionalProperties === 'object') {
-                expect((def.additionalProperties as any).type).toEqual('string');
-            } else {
-                // Current behavior: just sets true — documents the known limitation
-                expect(def.additionalProperties).toBe(true);
-            }
+            // V2 generator uses boolean additionalProperties (doesn't preserve type)
+            expect(def.additionalProperties).toBe(true);
         });
 
         it('should support additionalProperties alongside named properties', () => {
@@ -140,12 +136,11 @@ describe('additionalProperties', () => {
 
         it('should not use bare $ref in additionalProperties', () => {
             const schema = specV3.components.schemas!.StringMap;
-            if (typeof schema.additionalProperties === 'object') {
-                const ap = schema.additionalProperties as any;
-                if (ap.$ref) {
-                    expect(Object.keys(ap)).toEqual(['$ref']);
-                }
-            }
+            expect(typeof schema.additionalProperties).toBe('object');
+            const ap = schema.additionalProperties as any;
+            // StringMap has string additionalProperties, not a $ref
+            expect(ap.type).toEqual('string');
+            expect(ap.$ref).toBeUndefined();
         });
     });
 });

--- a/packages/swagger/test/unit/specification/nullable-types.spec.ts
+++ b/packages/swagger/test/unit/specification/nullable-types.spec.ts
@@ -143,18 +143,11 @@ describe('nullable types', () => {
 
         it('should handle nullable reference type with allOf wrapper', () => {
             const prop = specV3.components.schemas!.NullableModel.properties!.nullableRef;
-            // Must be one of: bare $ref (no nullable sibling) or allOf wrapper with nullable
-            const hasBareRef = '$ref' in prop && !('allOf' in prop);
-            const hasAllOfWrapper = 'allOf' in prop;
-            expect(hasBareRef || hasAllOfWrapper, 'expected $ref or allOf wrapper').toBe(true);
-
-            if (hasBareRef) {
-                expect(prop).not.toHaveProperty('nullable');
-            } else {
-                expect(prop.allOf).toHaveLength(1);
-                expect(prop.allOf[0].$ref).toBeDefined();
-                expect(prop.nullable).toBe(true);
-            }
+            // V3 wraps nullable refs in allOf to avoid sibling properties next to $ref
+            expect(prop).toHaveProperty('allOf');
+            expect(prop.allOf).toHaveLength(1);
+            expect(prop.allOf[0].$ref).toEqual('#/components/schemas/InnerModel');
+            expect(prop.nullable).toBe(true);
         });
 
         it('should not mark non-nullable fields as nullable', () => {

--- a/packages/swagger/test/unit/specification/nullable-types.spec.ts
+++ b/packages/swagger/test/unit/specification/nullable-types.spec.ts
@@ -144,6 +144,7 @@ describe('nullable types', () => {
         it('should handle nullable reference type with allOf wrapper', () => {
             const prop = specV3.components.schemas!.NullableModel.properties!.nullableRef;
             // V3 wraps nullable refs in allOf to avoid sibling properties next to $ref
+            expect(prop).not.toHaveProperty('$ref');
             expect(prop).toHaveProperty('allOf');
             expect(prop.allOf).toHaveLength(1);
             expect(prop.allOf[0].$ref).toEqual('#/components/schemas/InnerModel');


### PR DESCRIPTION
closes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for more TypeScript utility types and explicit tuple handling across metadata and schema generation.

* **Tests**
  * Added comprehensive tests for utility-type resolutions and tuples; tightened existing type-related assertions for determinism.

* **Refactor**
  * Reworked type-resolution flow for clearer, more consistent metadata outputs and cleaner utility-type handling.

* **Documentation**
  * Clarified architecture and testing conventions for metadata fidelity and stricter assertion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->