### PR TITLE
feat(metadata,swagger): oneOf composition, conditional types, and gen…

### DIFF
--- a/packages/decorators/test/data/controllers/conditional-types.ts
+++ b/packages/decorators/test/data/controllers/conditional-types.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Controller,
+    Get,
+    Mount,
+} from '../../../src';
+
+type Foo = {
+    bar: string,
+    baz: string
+};
+
+// Conditional type: resolves to Foo since string extends string
+type ConditionalFoo = string extends string ? Foo : never;
+
+// Wrapped generic utility type: Box<T> = Awaited<T>
+type Box<T> = Awaited<T>;
+type UnboxedFoo = Box<Promise<Foo>>;
+
+// Nested wrapped generic: MyPick<T, K> = Pick<T, K>
+type MyPick<T, K extends keyof T> = Pick<T, K>;
+type PickedFoo = MyPick<Foo, 'bar'>;
+
+@Controller()
+@Mount('conditional-types')
+export class ConditionalTypesController {
+    @Get()
+    @Mount('conditional')
+    public conditional(): ConditionalFoo {
+        return { bar: 'a', baz: 'b' };
+    }
+
+    @Get()
+    @Mount('wrapped-awaited')
+    public wrappedAwaited(): UnboxedFoo {
+        return { bar: 'a', baz: 'b' };
+    }
+
+    @Get()
+    @Mount('wrapped-pick')
+    public wrappedPick(): PickedFoo {
+        return { bar: 'a' };
+    }
+}

--- a/packages/decorators/test/data/controllers/conditional-types.ts
+++ b/packages/decorators/test/data/controllers/conditional-types.ts
@@ -56,13 +56,19 @@ export class ConditionalTypesController {
         return { bar: 'a' };
     }
 
-    // Regression test for #753: @types/node defines Headers via a conditional
-    // like `typeof globalThis extends { onmessage: any } ? {} : SomeClass`.
-    // This synthetic conditional mimics that pattern to verify the resolver
-    // handles typeof-globalThis conditional types without crashing.
+    // Regression test for #753: typeof-globalThis conditional pattern.
+    @Get()
+    @Mount('web-conditional')
+    public webConditional(): WebStyleConditional {
+        return { resolved: true };
+    }
+
+    // Regression test for #753: the global Headers type from @types/node
+    // uses a complex declaration chain (interface extends conditional type).
+    // The resolver must handle this via the checker fallback.
     @Get()
     @Mount('web-headers')
-    public webHeaders(): WebStyleConditional {
-        return { resolved: true };
+    public webHeaders(): Headers {
+        return new Headers();
     }
 }

--- a/packages/decorators/test/data/controllers/conditional-types.ts
+++ b/packages/decorators/test/data/controllers/conditional-types.ts
@@ -19,6 +19,14 @@ type Foo = {
 // Conditional type: resolves to Foo since string extends string
 type ConditionalFoo = string extends string ? Foo : never;
 
+// Regression test for #753: mimics the typeof-globalThis conditional
+// pattern used by @types/node for web standard types like Headers.
+// With `types: ['node']`, globalThis has onmessage, so this resolves to
+// the true branch — just like @types/node's `_Headers` resolves to `{}`.
+type WebStyleConditional = typeof globalThis extends { onmessage: any } ?
+    { resolved: boolean } :
+    { fallback: boolean };
+
 // Wrapped generic utility type: Box<T> = Awaited<T>
 type Box<T> = Awaited<T>;
 type UnboxedFoo = Box<Promise<Foo>>;
@@ -46,5 +54,15 @@ export class ConditionalTypesController {
     @Mount('wrapped-pick')
     public wrappedPick(): PickedFoo {
         return { bar: 'a' };
+    }
+
+    // Regression test for #753: @types/node defines Headers via a conditional
+    // like `typeof globalThis extends { onmessage: any } ? {} : SomeClass`.
+    // This synthetic conditional mimics that pattern to verify the resolver
+    // handles typeof-globalThis conditional types without crashing.
+    @Get()
+    @Mount('web-headers')
+    public webHeaders(): WebStyleConditional {
+        return { resolved: true };
     }
 }

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -55,7 +55,7 @@ import type {
     TypeNodeResolverContext,
     UsableDeclaration,
 } from './types';
-import { getNodeDescription, toTypeNodeOrFail } from './utils';
+import { getNodeDescription } from './utils';
 
 export class TypeNodeResolver extends ResolverBase {
     private static readonly MAX_DEPTH = 50;
@@ -181,91 +181,15 @@ export class TypeNodeResolver extends ResolverBase {
     // ------------------------------------------------------------------
 
     private resolveConditionalType(): Type | undefined {
-        if (
-            !ts.isConditionalTypeNode(this.typeNode) ||
-            !this.referencer ||
-            !ts.isTypeReferenceNode(this.referencer)
-        ) {
+        if (!ts.isConditionalTypeNode(this.typeNode)) {
             return undefined;
         }
 
-        const type = this.current.typeChecker.getTypeFromTypeNode(this.referencer);
-
-        if (type.aliasSymbol) {
-            let [declaration] = type.aliasSymbol.declarations as (
-                ts.TypeAliasDeclaration | ts.EnumDeclaration | ts.DeclarationStatement
-            )[];
-
-            if (declaration && declaration.name) {
-                declaration = this.getModelTypeDeclaration(
-                    declaration.name as ts.EntityName,
-                ) as ts.TypeAliasDeclaration |
-                ts.EnumDeclaration |
-                ts.DeclarationStatement;
-            }
-
-            const name = TypeNodeResolver.getRefTypeName(this.referencer.getText());
-            return this.handleCachingAndCircularReferences(name, () => {
-                if (declaration) {
-                    if (ts.isTypeAliasDeclaration(declaration)) {
-                        return this.getTypeAliasReference(
-                            declaration,
-                            this.current.typeChecker.typeToString(type),
-                            this.referencer as ts.TypeReferenceNode,
-                        );
-                    }
-
-                    if (ts.isEnumDeclaration(declaration)) {
-                        return this.getEnumerateType(declaration.name) as RefEnumType;
-                    }
-                }
-
-                const declarationKind = declaration ? ts.SyntaxKind[declaration.kind] : 'unknown';
-                throw new ResolverError(
-                    `Couldn't resolve Conditional to TypeNode. If you think this should be resolvable, please file an Issue. We found an aliasSymbol and its declaration was of kind ${declarationKind}`,
-                    this.typeNode,
-                );
-            });
-        }
-
-        if (type.isClassOrInterface()) {
-            let [declaration] = type.symbol.declarations as (
-                ts.InterfaceDeclaration | ts.ClassDeclaration
-            )[];
-            if (declaration && declaration.name) {
-                declaration = this.getModelTypeDeclaration(declaration.name) as ts.InterfaceDeclaration | ts.ClassDeclaration;
-            }
-
-            if (!declaration) {
-                throw new ResolverError('Couldn\'t get declaration for type symbol', this.typeNode);
-            }
-
-            const name = TypeNodeResolver.getRefTypeName(this.referencer.getText());
-            return this.handleCachingAndCircularReferences(name, () => this.getModelReference(
-                declaration,
-                this.current.typeChecker.typeToString(type),
-            ));
-        }
-
-        try {
-            return this.resolveNestedType(
-                toTypeNodeOrFail(
-                    this.current.typeChecker,
-                    type,
-                    undefined,
-                    ts.NodeBuilderFlags.NoTruncation,
-                ),
-                this.typeNode,
-                this.context,
-                this.referencer,
-            );
-        } catch (err) {
-            throw new ResolverError(
-                `Couldn't resolve Conditional to TypeNode. If you think this should be resolvable, please file an Issue. The flags on the result of the ConditionalType was ${type.flags}`,
-                this.typeNode,
-                { cause: err },
-            );
-        }
+        // Delegate conditional type evaluation to the TypeScript type
+        // checker. The checker can evaluate any conditional directly,
+        // including complex patterns like `typeof globalThis extends
+        // { onmessage: any } ? {} : X` from @types/node (#753).
+        return this.resolveTypeViaChecker(this.typeNode);
     }
 
     // ------------------------------------------------------------------
@@ -386,7 +310,25 @@ export class TypeNodeResolver extends ResolverBase {
     }
 
     private resolveUtilityTypeViaChecker(typeReference: ts.TypeReferenceNode): Type {
-        const type = this.current.typeChecker.getTypeFromTypeNode(typeReference);
+        // When type arguments reference unbound type parameters from our
+        // context (e.g. `Awaited<T>` inside `type Box<T> = Awaited<T>`),
+        // the checker can't resolve them from the declaration-site node.
+        // Use the referencer (usage-site node like `Box<Promise<Foo>>`)
+        // which the checker CAN resolve with concrete type arguments.
+        if (this.hasUnboundContextArgs(typeReference) && this.referencer) {
+            return this.resolveTypeViaChecker(this.referencer);
+        }
+
+        return this.resolveTypeViaChecker(typeReference);
+    }
+
+    /**
+     * Shared checker delegation: resolves a type node by letting the TS
+     * type checker evaluate it, converting back to a TypeNode, and
+     * recursively resolving the result.
+     */
+    private resolveTypeViaChecker(typeNode: ts.TypeNode): Type {
+        const type = this.current.typeChecker.getTypeFromTypeNode(typeNode);
         // InTypeAlias prevents the node builder from emitting type alias
         // references (which could cause circular resolution when the utility
         // type is used inside a type alias declaration).
@@ -408,6 +350,22 @@ export class TypeNodeResolver extends ResolverBase {
             this.parentNode,
             this.context,
         );
+    }
+
+    /**
+     * Check if a type reference has type arguments that reference unbound
+     * type parameters from this.context (e.g. `Awaited<T>` where T is a
+     * generic parameter mapped in context).
+     */
+    private hasUnboundContextArgs(typeReference: ts.TypeReferenceNode): boolean {
+        if (!typeReference.typeArguments || Object.keys(this.context).length === 0) {
+            return false;
+        }
+
+        return typeReference.typeArguments.some((arg) =>
+            ts.isTypeReferenceNode(arg) &&
+            ts.isIdentifier(arg.typeName) &&
+            arg.typeName.text in this.context);
     }
 
     private static resolveSpecialReference(node: ts.Identifier) : Type | undefined {

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -279,10 +279,22 @@ export class TypeNodeResolver extends ResolverBase {
             }
         }
 
-        const referenceType = this.getReferenceType(typeReference);
+        try {
+            const referenceType = this.getReferenceType(typeReference);
 
-        this.current.addReferenceType(referenceType);
-        return referenceType;
+            this.current.addReferenceType(referenceType);
+            return referenceType;
+        } catch (err) {
+            // When the model declaration walker fails (e.g. for global types
+            // like Headers, Request, Response from @types/node that use
+            // complex declaration patterns — #753), fall back to the checker.
+            // If the checker also fails, re-throw the original error.
+            try {
+                return this.resolveTypeViaChecker(typeReference);
+            } catch {
+                throw err;
+            }
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -56,6 +56,20 @@ describe('conditional type and generic context metadata extraction', () => {
         });
     });
 
+    describe('typeof-globalThis conditional types (#753)', () => {
+        it('should resolve typeof-globalThis conditional (mimics @types/node Headers pattern)', () => {
+            const method = getMethod('webHeaders');
+            // With types: ['node'], globalThis has onmessage, so the conditional
+            // resolves to the true branch: { resolved: boolean }
+            expect(method.type.typeName).toEqual('refAlias');
+            const alias = method.type as RefAliasType;
+            expect(alias.refName).toEqual('WebStyleConditional');
+            expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = alias.type as NestedObjectLiteralType;
+            expect(obj.properties.map((p) => p.name)).toEqual(['resolved']);
+        });
+    });
+
     describe('wrapped generic utility types (#777)', () => {
         it('should resolve Box<Promise<Foo>> (wrapped Awaited) to Foo shape', () => {
             const method = getMethod('wrappedAwaited');

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import path from 'node:path';
+import process from 'node:process';
+import type {
+    Metadata,
+    NestedObjectLiteralType,
+    RefAliasType,
+} from '../../../src';
+import { generateMetadata } from '../../../src';
+
+describe('conditional type and generic context metadata extraction', () => {
+    let metadata: Metadata;
+
+    beforeAll(async () => {
+        metadata = await generateMetadata({
+            entryPoint: [{
+                cwd: path.join(process.cwd(), '..', 'decorators'),
+                pattern: './test/data/controllers/conditional-types.ts',
+            }],
+            cache: false,
+            preset: '@trapi/decorators',
+        });
+    });
+
+    function getMethod(methodName: string) {
+        const controller = metadata.controllers.find(
+            (c) => c.name === 'ConditionalTypesController',
+        )!;
+        const method = controller.methods.find((m) => m.name === methodName)!;
+        expect(method).toBeDefined();
+        return method;
+    }
+
+    describe('conditional types (#753)', () => {
+        it('should resolve conditional type to the true branch', () => {
+            const method = getMethod('conditional');
+            expect(method.type.typeName).toEqual('refAlias');
+            const alias = method.type as RefAliasType;
+            expect(alias.refName).toEqual('ConditionalFoo');
+            expect(alias.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = alias.type as NestedObjectLiteralType;
+            const propNames = obj.properties.map((p) => p.name).sort();
+            expect(propNames).toEqual(['bar', 'baz']);
+        });
+    });
+
+    describe('wrapped generic utility types (#777)', () => {
+        it('should resolve Box<Promise<Foo>> (wrapped Awaited) to Foo shape', () => {
+            const method = getMethod('wrappedAwaited');
+            expect(method.type.typeName).toEqual('refAlias');
+            const outer = method.type as RefAliasType;
+            expect(outer.refName).toEqual('UnboxedFoo');
+            // Inner is BoxPromiseFoo → nestedObjectLiteral
+            expect(outer.type.typeName).toEqual('refAlias');
+            const inner = outer.type as RefAliasType;
+            expect(inner.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = inner.type as NestedObjectLiteralType;
+            const propNames = obj.properties.map((p) => p.name).sort();
+            expect(propNames).toEqual(['bar', 'baz']);
+        });
+
+        it('should resolve MyPick<Foo, "bar"> (wrapped Pick) to only bar property', () => {
+            const method = getMethod('wrappedPick');
+            expect(method.type.typeName).toEqual('refAlias');
+            const outer = method.type as RefAliasType;
+            expect(outer.refName).toEqual('PickedFoo');
+            expect(outer.type.typeName).toEqual('refAlias');
+            const inner = outer.type as RefAliasType;
+            expect(inner.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = inner.type as NestedObjectLiteralType;
+            expect(obj.properties).toHaveLength(1);
+            expect(obj.properties[0].name).toEqual('bar');
+        });
+    });
+});

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -57,8 +57,8 @@ describe('conditional type and generic context metadata extraction', () => {
     });
 
     describe('typeof-globalThis conditional types (#753)', () => {
-        it('should resolve typeof-globalThis conditional (mimics @types/node Headers pattern)', () => {
-            const method = getMethod('webHeaders');
+        it('should resolve typeof-globalThis conditional pattern', () => {
+            const method = getMethod('webConditional');
             // With types: ['node'], globalThis has onmessage, so the conditional
             // resolves to the true branch: { resolved: boolean }
             expect(method.type.typeName).toEqual('refAlias');
@@ -67,6 +67,15 @@ describe('conditional type and generic context metadata extraction', () => {
             expect(alias.type.typeName).toEqual('nestedObjectLiteral');
             const obj = alias.type as NestedObjectLiteralType;
             expect(obj.properties.map((p) => p.name)).toEqual(['resolved']);
+        });
+
+        it('should resolve global Headers type from @types/node (#753)', () => {
+            const method = getMethod('webHeaders');
+            // The global Headers type from @types/node uses a complex
+            // declaration chain (interface extends conditional type).
+            // The resolver must handle this via the checker fallback.
+            expect(method.type.typeName).toBeDefined();
+            expect(method.type.typeName).not.toEqual('void');
         });
     });
 

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -653,10 +653,19 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
     }
 
     private static isObjectLikeType(type: Type): boolean {
-        return isRefObjectType(type) ||
-            isRefAliasType(type) ||
+        if (isRefObjectType(type) ||
             isNestedObjectLiteralType(type) ||
-            isIntersectionType(type);
+            isIntersectionType(type)) {
+            return true;
+        }
+
+        // Unwrap refAlias to check the underlying type — a refAlias
+        // wrapping a primitive (e.g. `type Id = string`) is not object-like.
+        if (isRefAliasType(type)) {
+            return V3Generator.isObjectLikeType(type.type);
+        }
+
+        return false;
     }
 
     private applyDiscriminator(schema: SchemaV3, members: Type[]): void {
@@ -701,6 +710,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                 const memberProp = member!.properties.find((p) => p.name === propName);
                 if (
                     !memberProp ||
+                    !memberProp.required ||
                     memberProp.type.typeName !== 'enum' ||
                     (memberProp.type as EnumType).members.length !== 1
                 ) {

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -13,6 +13,7 @@ import type {
     Method,
     Parameter,
     RefEnumType,
+    RefObjectType,
     ResolverProperty,
     Response,
     Type,
@@ -23,7 +24,9 @@ import {
     TypeName,
     isAnyType,
     isEnumType,
+    isIntersectionType,
     isNestedObjectLiteralType,
+    isRefAliasType,
     isRefObjectType,
     isUndefinedType,
     isVoidType,
@@ -605,8 +608,14 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
             schemas.push(this.getSchemaForEnumType(enumType));
         }
 
+        // Use oneOf when all non-enum members are object-like types
+        const useOneOf = members.length > 0 &&
+            enumMembersKeys.length === 0 &&
+            members.every((m) => V3Generator.isObjectLikeType(m));
+
+        const compositionKey = useOneOf ? 'oneOf' : 'anyOf';
+
         if (this.isV31OrLater()) {
-            // 3.1+: add { type: 'null' } to anyOf for nullable unions
             if (nullable) {
                 schemas.push({ type: 'null' } as unknown as SchemaV3);
             }
@@ -615,7 +624,11 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                 return schemas[0];
             }
 
-            return { anyOf: schemas };
+            const schema: SchemaV3 = { [compositionKey]: schemas };
+            if (useOneOf) {
+                this.applyDiscriminator(schema, members);
+            }
+            return schema;
         }
 
         // 3.0: use nullable keyword
@@ -629,6 +642,85 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
             return { ...schema, nullable };
         }
 
-        return { anyOf: schemas, ...(nullable ? { nullable } : {}) };
+        const schema: SchemaV3 = {
+            [compositionKey]: schemas,
+            ...(nullable ? { nullable } : {}),
+        };
+        if (useOneOf) {
+            this.applyDiscriminator(schema, members);
+        }
+        return schema;
+    }
+
+    private static isObjectLikeType(type: Type): boolean {
+        return isRefObjectType(type) ||
+            isRefAliasType(type) ||
+            isNestedObjectLiteralType(type) ||
+            isIntersectionType(type);
+    }
+
+    private applyDiscriminator(schema: SchemaV3, members: Type[]): void {
+        const discriminator = this.detectDiscriminator(members);
+        if (discriminator) {
+            schema.discriminator = discriminator;
+        }
+    }
+
+    private detectDiscriminator(
+        members: Type[],
+    ): { propertyName: string; mapping: Record<string, string> } | undefined {
+        // All members must be ref objects so we can inspect their properties
+        if (!members.every((m) => isRefObjectType(m))) {
+            return undefined;
+        }
+
+        const refMembers = members as RefObjectType[];
+        const resolvedMembers = refMembers.map((m) => {
+            const resolved = this.metadata.referenceTypes[m.refName];
+            return resolved && resolved.typeName === 'refObject' ?
+                resolved as RefObjectType :
+                undefined;
+        });
+
+        if (resolvedMembers.some((m) => !m)) {
+            return undefined;
+        }
+
+        // Find a common property with distinct enum literal values in each member
+        const firstProps = resolvedMembers[0]!.properties;
+        for (const prop of firstProps) {
+            if (prop.type.typeName !== 'enum') continue;
+            const enumType = prop.type as EnumType;
+            if (enumType.members.length !== 1) continue;
+
+            const propName = prop.name;
+            const mapping: Record<string, string> = {};
+            let isDiscriminator = true;
+
+            for (const member of resolvedMembers) {
+                const memberProp = member!.properties.find((p) => p.name === propName);
+                if (
+                    !memberProp ||
+                    memberProp.type.typeName !== 'enum' ||
+                    (memberProp.type as EnumType).members.length !== 1
+                ) {
+                    isDiscriminator = false;
+                    break;
+                }
+
+                const value = String((memberProp.type as EnumType).members[0]);
+                if (mapping[value]) {
+                    isDiscriminator = false;
+                    break;
+                }
+                mapping[value] = `${this.getRefPrefix()}${member!.refName}`;
+            }
+
+            if (isDiscriminator && Object.keys(mapping).length === members.length) {
+                return { propertyName: propName, mapping };
+            }
+        }
+
+        return undefined;
     }
 }

--- a/packages/swagger/src/schema/types.ts
+++ b/packages/swagger/src/schema/types.ts
@@ -102,7 +102,7 @@ export interface BaseSchema<T> {
     items?: T | BaseSchema<T> | any;
     additionalProperties?: boolean | { [ref: string]: string } | T;
     properties?: { [propertyName: string]: T };
-    discriminator?: string;
+    discriminator?: string | { propertyName: string; mapping?: Record<string, string> };
     readOnly?: boolean;
     xml?: XML;
     externalDocs?: ExternalDocs;

--- a/packages/swagger/src/schema/types.ts
+++ b/packages/swagger/src/schema/types.ts
@@ -102,7 +102,7 @@ export interface BaseSchema<T> {
     items?: T | BaseSchema<T> | any;
     additionalProperties?: boolean | { [ref: string]: string } | T;
     properties?: { [propertyName: string]: T };
-    discriminator?: string | { propertyName: string; mapping?: Record<string, string> };
+    discriminator?: string;
     readOnly?: boolean;
     xml?: XML;
     externalDocs?: ExternalDocs;

--- a/packages/swagger/src/schema/v3/types.ts
+++ b/packages/swagger/src/schema/v3/types.ts
@@ -158,6 +158,7 @@ export interface SchemaV3 extends BaseSchema<SchemaV3> {
     nullable?: boolean;
     anyOf?: SchemaV3[];
     allOf?: SchemaV3[];
+    oneOf?: SchemaV3[];
     deprecated?: boolean;
 }
 

--- a/packages/swagger/src/schema/v3/types.ts
+++ b/packages/swagger/src/schema/v3/types.ts
@@ -77,7 +77,7 @@ export interface BaseParameterV3 {
     explode?: boolean,
     allowReserved?: boolean,
 
-    schema?: BaseSchema<SchemaV3>,
+    schema?: SchemaV3,
     example?: unknown;
     examples?: Record<string, Example | string>;
 
@@ -135,7 +135,7 @@ export interface HeaderV3 extends Omit<BaseSchema<SchemaV3>, 'required'> {
     description?: string;
     example?: unknown;
     examples?: Record<string, Example | string>;
-    schema: BaseSchema<SchemaV3>;
+    schema: SchemaV3;
     type?: `${DataTypeName}`;
     format?: `${DataFormatName}`;
 }
@@ -154,7 +154,8 @@ export interface MediaTypeV3 {
 }
 
 // tslint:disable-next-line:no-shadowed-variable
-export interface SchemaV3 extends BaseSchema<SchemaV3> {
+export interface SchemaV3 extends Omit<BaseSchema<SchemaV3>, 'discriminator'> {
+    discriminator?: string | { propertyName: string; mapping?: Record<string, string> };
     nullable?: boolean;
     anyOf?: SchemaV3[];
     allOf?: SchemaV3[];

--- a/packages/swagger/test/unit/specification/union-composition.spec.ts
+++ b/packages/swagger/test/unit/specification/union-composition.spec.ts
@@ -29,6 +29,7 @@ import {
 describe('union composition (oneOf / discriminator)', () => {
     let specV2: SpecV2;
     let specV3: SpecV3;
+    let specV31: SpecV3;
 
     const referenceTypes = {
         User: createRefObject('User', [
@@ -178,6 +179,15 @@ describe('union composition (oneOf / discriminator)', () => {
                 metadata,
             },
         });
+
+        specV31 = await generate({
+            version: Version.V3_1,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
     });
 
     describe('V3 oneOf', () => {
@@ -213,6 +223,28 @@ describe('union composition (oneOf / discriminator)', () => {
             expect(schema).toHaveProperty('oneOf');
             expect(schema.oneOf).toHaveLength(2);
             expect(schema.nullable).toBe(true);
+        });
+    });
+
+    describe('V3.1 oneOf (type: null instead of nullable)', () => {
+        it('should use oneOf for object union', () => {
+            const { schema } = specV31.paths['/composition/result'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema).not.toHaveProperty('anyOf');
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf![0].$ref).toEqual('#/components/schemas/User');
+            expect(schema.oneOf![1].$ref).toEqual('#/components/schemas/ErrorModel');
+        });
+
+        it('should use { type: "null" } instead of nullable for nullable object union', () => {
+            const { schema } = specV31.paths['/composition/nullable'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema).not.toHaveProperty('nullable');
+            // 3.1+: nullable members are represented as { type: 'null' } in the oneOf array
+            const nullMember = schema.oneOf!.find((s: any) => s.type === 'null');
+            expect(nullMember).toBeDefined();
+            // Two object refs + null type member
+            expect(schema.oneOf).toHaveLength(3);
         });
     });
 

--- a/packages/swagger/test/unit/specification/union-composition.spec.ts
+++ b/packages/swagger/test/unit/specification/union-composition.spec.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { SpecV2, SpecV3 } from '../../../src';
+import { Version, generate } from '../../../src';
+import {
+    createController,
+    createMetadata,
+    createMethod,
+    createProperty,
+    createRefObject,
+    createResponse,
+    enumType,
+    refObjectType,
+    stringType,
+    unionType,
+} from '../../helpers/metadata-builder';
+
+describe('union composition (oneOf / discriminator)', () => {
+    let specV2: SpecV2;
+    let specV3: SpecV3;
+
+    const referenceTypes = {
+        User: createRefObject('User', [
+            createProperty({ name: 'id', type: { typeName: 'integer' } }),
+            createProperty({ name: 'name', type: stringType() }),
+        ]),
+        ErrorModel: createRefObject('ErrorModel', [
+            createProperty({ name: 'code', type: { typeName: 'integer' } }),
+            createProperty({ name: 'message', type: stringType() }),
+        ]),
+        Circle: createRefObject('Circle', [
+            createProperty({ name: 'kind', type: enumType(['circle']) }),
+            createProperty({ name: 'radius', type: { typeName: 'double' } }),
+        ]),
+        Square: createRefObject('Square', [
+            createProperty({ name: 'kind', type: enumType(['square']) }),
+            createProperty({ name: 'side', type: { typeName: 'double' } }),
+        ]),
+    };
+
+    const metadata = createMetadata(
+        [
+            createController({
+                name: 'CompositionController',
+                path: 'composition',
+                methods: [
+                    createMethod({
+                        name: 'getResult',
+                        method: 'get',
+                        path: 'result',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('User'),
+                                    refObjectType('ErrorModel'),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('User'),
+                            refObjectType('ErrorModel'),
+                        ]),
+                    }),
+                    createMethod({
+                        name: 'getShape',
+                        method: 'get',
+                        path: 'shape',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('Circle'),
+                                    refObjectType('Square'),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('Circle'),
+                            refObjectType('Square'),
+                        ]),
+                    }),
+                    createMethod({
+                        name: 'getStatus',
+                        method: 'get',
+                        path: 'status',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    enumType(['active']),
+                                    enumType(['inactive']),
+                                    enumType(['deleted']),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            enumType(['active']),
+                            enumType(['inactive']),
+                            enumType(['deleted']),
+                        ]),
+                    }),
+                    createMethod({
+                        name: 'getMixed',
+                        method: 'get',
+                        path: 'mixed',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('User'),
+                                    stringType(),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('User'),
+                            stringType(),
+                        ]),
+                    }),
+                    createMethod({
+                        name: 'getNullableResult',
+                        method: 'get',
+                        path: 'nullable',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('User'),
+                                    refObjectType('ErrorModel'),
+                                    enumType([null]),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('User'),
+                            refObjectType('ErrorModel'),
+                            enumType([null]),
+                        ]),
+                    }),
+                ],
+            }),
+        ],
+        referenceTypes,
+    );
+
+    beforeAll(async () => {
+        specV2 = await generate({
+            version: Version.V2,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+
+        specV3 = await generate({
+            version: Version.V3,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+    });
+
+    describe('V3 oneOf', () => {
+        it('should use oneOf for object union (User | ErrorModel)', () => {
+            const { schema } = specV3.paths['/composition/result'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema).not.toHaveProperty('anyOf');
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf[0].$ref).toEqual('#/components/schemas/User');
+            expect(schema.oneOf[1].$ref).toEqual('#/components/schemas/ErrorModel');
+        });
+
+        it('should use enum for string literal union (not oneOf)', () => {
+            const { schema } = specV3.paths['/composition/status'].get!.responses['200'].content['application/json'];
+            expect(schema).not.toHaveProperty('oneOf');
+            expect(schema).not.toHaveProperty('anyOf');
+            expect(schema.type).toEqual('string');
+            expect(schema.enum).toBeDefined();
+            expect(schema.enum).toContain('active');
+            expect(schema.enum).toContain('inactive');
+            expect(schema.enum).toContain('deleted');
+        });
+
+        it('should use anyOf for mixed union (object + primitive)', () => {
+            const { schema } = specV3.paths['/composition/mixed'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('anyOf');
+            expect(schema).not.toHaveProperty('oneOf');
+            expect(schema.anyOf).toHaveLength(2);
+        });
+
+        it('should use oneOf with nullable for nullable object union', () => {
+            const { schema } = specV3.paths['/composition/nullable'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.nullable).toBe(true);
+        });
+    });
+
+    describe('V3 discriminator', () => {
+        it('should detect discriminator for discriminated union (Circle | Square)', () => {
+            const { schema } = specV3.paths['/composition/shape'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema).toHaveProperty('discriminator');
+            const disc = schema.discriminator as { propertyName: string; mapping?: Record<string, string> };
+            expect(disc.propertyName).toEqual('kind');
+            expect(disc.mapping).toEqual({
+                circle: '#/components/schemas/Circle',
+                square: '#/components/schemas/Square',
+            });
+        });
+
+        it('should not add discriminator for non-discriminated object union', () => {
+            const { schema } = specV3.paths['/composition/result'].get!.responses['200'].content['application/json'];
+            expect(schema).toHaveProperty('oneOf');
+            expect(schema).not.toHaveProperty('discriminator');
+        });
+    });
+
+    describe('V2 unchanged', () => {
+        it('should not use oneOf in V2 output', () => {
+            const response = specV2.paths['/composition/result'].get!.responses['200'];
+            expect(response.schema).not.toHaveProperty('oneOf');
+        });
+    });
+});


### PR DESCRIPTION
…eric context resolution

closes #758
closes #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for TypeScript conditional/utility type resolution in metadata generation.
  * OpenAPI v3 schema generation: use oneOf for object-like unions and attach discriminators when detectable.
  * Extended OpenAPI v3 schema typing to formally support discriminator and oneOf.

* **Tests**
  * Added unit tests covering conditional-type resolution and union composition/discriminator behavior across OpenAPI versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->