### PR TITLE
fix(metadata,swagger): generic conditional resolution and refAlias di…

### DIFF
--- a/packages/decorators/test/data/controllers/conditional-types.ts
+++ b/packages/decorators/test/data/controllers/conditional-types.ts
@@ -30,6 +30,7 @@ type WebStyleConditional = typeof globalThis extends { onmessage: any } ?
 // Generic conditional type: resolves based on the type argument (#782)
 type ConditionalGeneric<T> = T extends string ? { strVal: string } : { otherVal: number };
 type ResolvedConditionalGeneric = ConditionalGeneric<string>;
+type ResolvedConditionalGenericFalse = ConditionalGeneric<number>;
 
 // Wrapped generic utility type: Box<T> = Awaited<T>
 type Box<T> = Awaited<T>;
@@ -64,6 +65,12 @@ export class ConditionalTypesController {
     @Mount('conditional-generic')
     public conditionalGeneric(): ResolvedConditionalGeneric {
         return { strVal: 'hello' };
+    }
+
+    @Get()
+    @Mount('conditional-generic-false')
+    public conditionalGenericFalse(): ResolvedConditionalGenericFalse {
+        return { otherVal: 42 };
     }
 
     // Regression test for #753: typeof-globalThis conditional pattern.

--- a/packages/decorators/test/data/controllers/conditional-types.ts
+++ b/packages/decorators/test/data/controllers/conditional-types.ts
@@ -27,6 +27,10 @@ type WebStyleConditional = typeof globalThis extends { onmessage: any } ?
     { resolved: boolean } :
     { fallback: boolean };
 
+// Generic conditional type: resolves based on the type argument (#782)
+type ConditionalGeneric<T> = T extends string ? { strVal: string } : { otherVal: number };
+type ResolvedConditionalGeneric = ConditionalGeneric<string>;
+
 // Wrapped generic utility type: Box<T> = Awaited<T>
 type Box<T> = Awaited<T>;
 type UnboxedFoo = Box<Promise<Foo>>;
@@ -54,6 +58,12 @@ export class ConditionalTypesController {
     @Mount('wrapped-pick')
     public wrappedPick(): PickedFoo {
         return { bar: 'a' };
+    }
+
+    @Get()
+    @Mount('conditional-generic')
+    public conditionalGeneric(): ResolvedConditionalGeneric {
+        return { strVal: 'hello' };
     }
 
     // Regression test for #753: typeof-globalThis conditional pattern.

--- a/packages/metadata/src/resolver/module.ts
+++ b/packages/metadata/src/resolver/module.ts
@@ -185,6 +185,13 @@ export class TypeNodeResolver extends ResolverBase {
             return undefined;
         }
 
+        // When inside a generic type alias (context has entries) and we
+        // have a usage-site node (referencer), resolve via the referencer
+        // so the checker evaluates with concrete type arguments (#782).
+        if (Object.keys(this.context).length > 0 && this.referencer) {
+            return this.resolveTypeViaChecker(this.referencer);
+        }
+
         // Delegate conditional type evaluation to the TypeScript type
         // checker. The checker can evaluate any conditional directly,
         // including complex patterns like `typeof globalThis extends

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -69,6 +69,18 @@ describe('conditional type and generic context metadata extraction', () => {
             const obj = inner.type as NestedObjectLiteralType;
             expect(obj.properties.map((p) => p.name)).toEqual(['strVal']);
         });
+
+        it('should resolve ConditionalGeneric<number> to the false branch', () => {
+            const method = getMethod('conditionalGenericFalse');
+            expect(method.type.typeName).toEqual('refAlias');
+            const outer = method.type as RefAliasType;
+            expect(outer.refName).toEqual('ResolvedConditionalGenericFalse');
+            expect(outer.type.typeName).toEqual('refAlias');
+            const inner = outer.type as RefAliasType;
+            expect(inner.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = inner.type as NestedObjectLiteralType;
+            expect(obj.properties.map((p) => p.name)).toEqual(['otherVal']);
+        });
     });
 
     describe('typeof-globalThis conditional types (#753)', () => {

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -56,6 +56,21 @@ describe('conditional type and generic context metadata extraction', () => {
         });
     });
 
+    describe('generic conditional types (#782)', () => {
+        it('should resolve ConditionalGeneric<string> to the true branch', () => {
+            const method = getMethod('conditionalGeneric');
+            expect(method.type.typeName).toEqual('refAlias');
+            const outer = method.type as RefAliasType;
+            expect(outer.refName).toEqual('ResolvedConditionalGeneric');
+            // Inner is ConditionalGeneric<string> → resolves to { strVal: string }
+            expect(outer.type.typeName).toEqual('refAlias');
+            const inner = outer.type as RefAliasType;
+            expect(inner.type.typeName).toEqual('nestedObjectLiteral');
+            const obj = inner.type as NestedObjectLiteralType;
+            expect(obj.properties.map((p) => p.name)).toEqual(['strVal']);
+        });
+    });
+
     describe('typeof-globalThis conditional types (#753)', () => {
         it('should resolve typeof-globalThis conditional pattern', () => {
             const method = getMethod('webConditional');

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -11,7 +11,9 @@ import type {
     IntersectionType,
     Metadata,
     Method,
+    NestedObjectLiteralType,
     Parameter,
+    RefAliasType,
     RefEnumType,
     RefObjectType,
     ResolverProperty,
@@ -678,19 +680,9 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
     private detectDiscriminator(
         members: Type[],
     ): { propertyName: string; mapping: Record<string, string> } | undefined {
-        // All members must be ref objects so we can inspect their properties
-        if (!members.every((m) => isRefObjectType(m))) {
-            return undefined;
-        }
-
-        const refMembers = members as RefObjectType[];
-        const resolvedMembers = refMembers.map((m) => {
-            const resolved = this.metadata.referenceTypes[m.refName];
-            return resolved && resolved.typeName === 'refObject' ?
-                resolved as RefObjectType :
-                undefined;
-        });
-
+        // Resolve each member to { refName, properties }. Supports both
+        // refObject and refAlias members (#783).
+        const resolvedMembers = members.map((m) => this.resolveDiscriminatorMember(m));
         if (resolvedMembers.some((m) => !m)) {
             return undefined;
         }
@@ -728,6 +720,53 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
 
             if (isDiscriminator && Object.keys(mapping).length === members.length) {
                 return { propertyName: propName, mapping };
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Resolve a union member to its refName and properties for discriminator
+     * detection. Accepts both refObject and refAlias members, unwrapping
+     * aliases to find the underlying properties while preserving the
+     * original refName for $ref mapping.
+     */
+    private resolveDiscriminatorMember(
+        member: Type,
+    ): { refName: string; properties: ResolverProperty[] } | undefined {
+        if (!isRefObjectType(member) && !isRefAliasType(member)) {
+            return undefined;
+        }
+
+        const { refName } = member as RefObjectType | RefAliasType;
+        const referenceType = this.metadata.referenceTypes[refName];
+        if (!referenceType) {
+            return undefined;
+        }
+
+        if (referenceType.typeName === 'refObject') {
+            return { refName, properties: (referenceType as RefObjectType).properties };
+        }
+
+        if (referenceType.typeName === 'refAlias') {
+            let inner: Type = (referenceType as RefAliasType).type;
+            for (let depth = 0; depth < 10; depth++) {
+                if (isRefObjectType(inner)) {
+                    const resolved = this.metadata.referenceTypes[inner.refName];
+                    if (resolved?.typeName === 'refObject') {
+                        return { refName, properties: (resolved as RefObjectType).properties };
+                    }
+                    return undefined;
+                }
+                if (isNestedObjectLiteralType(inner)) {
+                    return { refName, properties: (inner as NestedObjectLiteralType).properties };
+                }
+                if (isRefAliasType(inner)) {
+                    inner = (inner as RefAliasType).type;
+                    continue;
+                }
+                return undefined;
             }
         }
 

--- a/packages/swagger/test/unit/specification/union-composition.spec.ts
+++ b/packages/swagger/test/unit/specification/union-composition.spec.ts
@@ -18,6 +18,7 @@ import {
     createMetadata,
     createMethod,
     createProperty,
+    createRefAlias,
     createRefObject,
     createResponse,
     enumType,
@@ -273,6 +274,78 @@ describe('union composition (oneOf / discriminator)', () => {
         it('should not use oneOf in V2 output', () => {
             const response = specV2.paths['/composition/result'].get!.responses['200'];
             expect(response.schema).not.toHaveProperty('oneOf');
+        });
+    });
+});
+
+describe('discriminator with refAlias members (#783)', () => {
+    let specV3Alias: SpecV3;
+
+    const aliasReferenceTypes = {
+        Circle: createRefObject('Circle', [
+            createProperty({ name: 'kind', type: enumType(['circle']) }),
+            createProperty({ name: 'radius', type: { typeName: 'double' } }),
+        ]),
+        Square: createRefObject('Square', [
+            createProperty({ name: 'kind', type: enumType(['square']) }),
+            createProperty({ name: 'side', type: { typeName: 'double' } }),
+        ]),
+        CircleAlias: createRefAlias('CircleAlias', refObjectType('Circle')),
+        SquareAlias: createRefAlias('SquareAlias', refObjectType('Square')),
+    };
+
+    const aliasMetadata = createMetadata(
+        [
+            createController({
+                name: 'AliasController',
+                path: 'alias',
+                methods: [
+                    createMethod({
+                        name: 'getShape',
+                        method: 'get',
+                        path: 'shape',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    createRefAlias('CircleAlias', refObjectType('Circle')),
+                                    createRefAlias('SquareAlias', refObjectType('Square')),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            createRefAlias('CircleAlias', refObjectType('Circle')),
+                            createRefAlias('SquareAlias', refObjectType('Square')),
+                        ]),
+                    }),
+                ],
+            }),
+        ],
+        aliasReferenceTypes,
+    );
+
+    beforeAll(async () => {
+        specV3Alias = await generate({
+            version: Version.V3,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata: aliasMetadata,
+            },
+        });
+    });
+
+    it('should detect discriminator for union of refAlias members', () => {
+        const { schema } = specV3Alias.paths['/alias/shape'].get!.responses['200'].content['application/json'];
+        expect(schema).toHaveProperty('oneOf');
+        expect(schema.oneOf).toHaveLength(2);
+        expect(schema).toHaveProperty('discriminator');
+        const disc = schema.discriminator as { propertyName: string; mapping?: Record<string, string> };
+        expect(disc.propertyName).toEqual('kind');
+        expect(disc.mapping).toEqual({
+            circle: '#/components/schemas/CircleAlias',
+            square: '#/components/schemas/SquareAlias',
         });
     });
 });

--- a/packages/swagger/test/unit/specification/union-composition.spec.ts
+++ b/packages/swagger/test/unit/specification/union-composition.spec.ts
@@ -349,3 +349,150 @@ describe('discriminator with refAlias members (#783)', () => {
         });
     });
 });
+
+describe('discriminator with refAlias wrapping nestedObjectLiteral (#783)', () => {
+    let specV3: SpecV3;
+
+    const referenceTypes = {
+        InlineCircle: createRefAlias('InlineCircle', {
+            typeName: 'nestedObjectLiteral',
+            properties: [
+                createProperty({ name: 'kind', type: enumType(['circle']) }),
+                createProperty({ name: 'radius', type: { typeName: 'double' } }),
+            ],
+        } as any),
+        InlineSquare: createRefAlias('InlineSquare', {
+            typeName: 'nestedObjectLiteral',
+            properties: [
+                createProperty({ name: 'kind', type: enumType(['square']) }),
+                createProperty({ name: 'side', type: { typeName: 'double' } }),
+            ],
+        } as any),
+    };
+
+    const metadata = createMetadata(
+        [
+            createController({
+                name: 'InlineController',
+                path: 'inline',
+                methods: [
+                    createMethod({
+                        name: 'getShape',
+                        method: 'get',
+                        path: 'shape',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    createRefAlias('InlineCircle', refObjectType('_unused')),
+                                    createRefAlias('InlineSquare', refObjectType('_unused')),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            createRefAlias('InlineCircle', refObjectType('_unused')),
+                            createRefAlias('InlineSquare', refObjectType('_unused')),
+                        ]),
+                    }),
+                ],
+            }),
+        ],
+        referenceTypes,
+    );
+
+    beforeAll(async () => {
+        specV3 = await generate({
+            version: Version.V3,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+    });
+
+    it('should detect discriminator for refAlias wrapping nestedObjectLiteral', () => {
+        const { schema } = specV3.paths['/inline/shape'].get!.responses['200'].content['application/json'];
+        expect(schema).toHaveProperty('oneOf');
+        expect(schema.oneOf).toHaveLength(2);
+        expect(schema).toHaveProperty('discriminator');
+        const disc = schema.discriminator as { propertyName: string; mapping?: Record<string, string> };
+        expect(disc.propertyName).toEqual('kind');
+        expect(disc.mapping).toEqual({
+            circle: '#/components/schemas/InlineCircle',
+            square: '#/components/schemas/InlineSquare',
+        });
+    });
+});
+
+describe('discriminator with mixed refObject + refAlias members (#783)', () => {
+    let specV3: SpecV3;
+
+    const referenceTypes = {
+        Circle: createRefObject('Circle', [
+            createProperty({ name: 'kind', type: enumType(['circle']) }),
+            createProperty({ name: 'radius', type: { typeName: 'double' } }),
+        ]),
+        Square: createRefObject('Square', [
+            createProperty({ name: 'kind', type: enumType(['square']) }),
+            createProperty({ name: 'side', type: { typeName: 'double' } }),
+        ]),
+        SquareAlias: createRefAlias('SquareAlias', refObjectType('Square')),
+    };
+
+    const metadata = createMetadata(
+        [
+            createController({
+                name: 'MixedController',
+                path: 'mixed',
+                methods: [
+                    createMethod({
+                        name: 'getShape',
+                        method: 'get',
+                        path: 'shape',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('Circle'),
+                                    createRefAlias('SquareAlias', refObjectType('Square')),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('Circle'),
+                            createRefAlias('SquareAlias', refObjectType('Square')),
+                        ]),
+                    }),
+                ],
+            }),
+        ],
+        referenceTypes,
+    );
+
+    beforeAll(async () => {
+        specV3 = await generate({
+            version: Version.V3,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+    });
+
+    it('should detect discriminator for mixed refObject + refAlias union', () => {
+        const { schema } = specV3.paths['/mixed/shape'].get!.responses['200'].content['application/json'];
+        expect(schema).toHaveProperty('oneOf');
+        expect(schema.oneOf).toHaveLength(2);
+        expect(schema).toHaveProperty('discriminator');
+        const disc = schema.discriminator as { propertyName: string; mapping?: Record<string, string> };
+        expect(disc.propertyName).toEqual('kind');
+        expect(disc.mapping).toEqual({
+            circle: '#/components/schemas/Circle',
+            square: '#/components/schemas/SquareAlias',
+        });
+    });
+});


### PR DESCRIPTION
…scriminator detection

closes #782 
closes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for generic conditional types in API metadata resolution and docs, plus sample endpoints demonstrating both branches of a conditional generic response.

* **Bug Fixes**
  * Improved discriminator detection to handle union members that use type aliases, preserving correct discriminator mappings in OpenAPI v3 output.

* **Tests**
  * Added unit tests covering conditional generic type resolution and alias-based union discriminator detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->