### PR TITLE
feat(metadata,swagger): add dedicated never type support

### DIFF
--- a/packages/decorators/test/data/controllers/never-type.ts
+++ b/packages/decorators/test/data/controllers/never-type.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Controller,
+    Get,
+    Mount,
+} from '../../../src';
+
+// Standalone never return type — function that always throws
+type AlwaysThrows = never;
+
+// Conditional type resolving to never (false branch of impossible condition)
+type NeverBranch = number extends string ? { value: string } : never;
+
+// Union containing never — never should be stripped
+type CleanUnion = string | never;
+
+@Controller()
+@Mount('never-type')
+export class NeverTypeController {
+    @Get()
+    @Mount('throws')
+    public alwaysThrows(): AlwaysThrows {
+        throw new Error('always throws');
+    }
+
+    @Get()
+    @Mount('never-branch')
+    public neverBranch(): NeverBranch {
+        throw new Error('unreachable');
+    }
+
+    @Get()
+    @Mount('clean-union')
+    public cleanUnion(): CleanUnion {
+        return 'hello';
+    }
+}

--- a/packages/decorators/test/data/controllers/never-type.ts
+++ b/packages/decorators/test/data/controllers/never-type.ts
@@ -17,7 +17,7 @@ type AlwaysThrows = never;
 // Conditional type resolving to never (false branch of impossible condition)
 type NeverBranch = number extends string ? { value: string } : never;
 
-// Union containing never — never should be stripped
+// Union containing never — preserved in metadata; stripped in swagger mapping
 type CleanUnion = string | never;
 
 @Controller()

--- a/packages/metadata/src/resolver/constants.ts
+++ b/packages/metadata/src/resolver/constants.ts
@@ -25,6 +25,7 @@ export enum TypeName {
     OBJECT = 'object',
     ANY = 'any',
     UNDEFINED = 'undefined',
+    NEVER = 'never',
     REF_ENUM = 'refEnum',
     REF_OBJECT = 'refObject',
     REF_ALIAS = 'refAlias',

--- a/packages/metadata/src/resolver/sub/primitive.ts
+++ b/packages/metadata/src/resolver/sub/primitive.ts
@@ -11,7 +11,7 @@ import type { IDecoratorResolver } from '../../decorator';
 import { DecoratorID } from '../../decorator';
 import { getJSDocTagNames } from '../../utils';
 import { TypeName } from '../constants';
-import type { PrimitiveType, VoidType } from '../types';
+import type { NeverType, PrimitiveType, VoidType } from '../types';
 
 export class PrimitiveResolver {
     protected decoratorResolver : IDecoratorResolver;
@@ -20,7 +20,7 @@ export class PrimitiveResolver {
         this.decoratorResolver = decoratorResolver;
     }
 
-    resolve(node: TypeNode, parentNode?: Node) : PrimitiveType | VoidType | undefined {
+    resolve(node: TypeNode, parentNode?: Node) : PrimitiveType | NeverType | VoidType | undefined {
         const resolved = this.resolveSyntaxKind(node.kind);
         if (resolved) {
             if (resolved === 'string') {
@@ -42,6 +42,10 @@ export class PrimitiveResolver {
             if (resolved === 'null') {
                 // todo: check
                 return undefined;
+            }
+
+            if (resolved === 'never') {
+                return { typeName: TypeName.NEVER };
             }
 
             if (resolved === 'bigint') {
@@ -123,6 +127,8 @@ export class PrimitiveResolver {
                 return 'number';
             case SyntaxKind.BigIntKeyword:
                 return 'bigint';
+            case SyntaxKind.NeverKeyword:
+                return 'never';
             default:
                 return undefined;
         }

--- a/packages/metadata/src/resolver/type-guards.ts
+++ b/packages/metadata/src/resolver/type-guards.ts
@@ -25,6 +25,7 @@ import type {
     IntersectionType,
     LongType,
     NestedObjectLiteralType,
+    NeverType,
     ObjectType,
     PrimitiveType,
     RefAliasType,
@@ -80,6 +81,10 @@ export function isLongType(param: BaseType): param is LongType {
 
 export function isVoidType(param: BaseType | undefined): param is VoidType {
     return typeof param === 'undefined' || param.typeName === TypeName.VOID;
+}
+
+export function isNeverType(param: BaseType): param is NeverType {
+    return param.typeName === TypeName.NEVER;
 }
 
 // -------------------------------------------

--- a/packages/metadata/src/resolver/types.ts
+++ b/packages/metadata/src/resolver/types.ts
@@ -23,6 +23,7 @@ export type Type = PrimitiveType |
         ByteType |
         AnyType |
         UndefinedType |
+        NeverType |
         RefEnumType |
         RefObjectType |
         RefAliasType |
@@ -80,6 +81,10 @@ export interface LongType extends BaseType {
 
 export interface VoidType extends BaseType {
     typeName: `${TypeName.VOID}`;
+}
+
+export interface NeverType extends BaseType {
+    typeName: `${TypeName.NEVER}`;
 }
 
 // -------------------------------------------

--- a/packages/metadata/test/unit/generator/complex-types.spec.ts
+++ b/packages/metadata/test/unit/generator/complex-types.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type {
     ArrayType,
     IntersectionType,
@@ -30,7 +30,7 @@ describe('complex type metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/conditional-types.spec.ts
+++ b/packages/metadata/test/unit/generator/conditional-types.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type {
     Metadata,
     NestedObjectLiteralType,
@@ -26,7 +26,7 @@ describe('conditional type and generic context metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/conditional-types.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/controller.spec.ts
+++ b/packages/metadata/test/unit/generator/controller.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { Metadata } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -22,7 +22,7 @@ describe('controller metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/metadata.spec.ts
+++ b/packages/metadata/test/unit/generator/metadata.spec.ts
@@ -12,7 +12,7 @@ import {
     it, 
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { Metadata, NestedObjectLiteralType, RefAliasType } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -22,7 +22,7 @@ describe('src/generator/metadata', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/never-type.spec.ts
+++ b/packages/metadata/test/unit/generator/never-type.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type {
     Metadata,
     RefAliasType,
@@ -26,7 +26,7 @@ describe('never type metadata extraction (#778)', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/never-type.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/never-type.spec.ts
+++ b/packages/metadata/test/unit/generator/never-type.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import path from 'node:path';
+import process from 'node:process';
+import type {
+    Metadata,
+    RefAliasType,
+    UnionType,
+} from '../../../src';
+import { generateMetadata } from '../../../src';
+
+describe('never type metadata extraction (#778)', () => {
+    let metadata: Metadata;
+
+    beforeAll(async () => {
+        metadata = await generateMetadata({
+            entryPoint: [{
+                cwd: path.join(process.cwd(), '..', 'decorators'),
+                pattern: './test/data/controllers/never-type.ts',
+            }],
+            cache: false,
+            preset: '@trapi/decorators',
+        });
+    });
+
+    function getMethod(methodName: string) {
+        const controller = metadata.controllers.find(
+            (c) => c.name === 'NeverTypeController',
+        )!;
+        const method = controller.methods.find((m) => m.name === methodName)!;
+        expect(method).toBeDefined();
+        return method;
+    }
+
+    it('should resolve standalone never return type', () => {
+        const method = getMethod('alwaysThrows');
+        expect(method.type.typeName).toEqual('refAlias');
+        const alias = method.type as RefAliasType;
+        expect(alias.refName).toEqual('AlwaysThrows');
+        expect(alias.type.typeName).toEqual('never');
+    });
+
+    it('should resolve conditional type with never branch', () => {
+        const method = getMethod('neverBranch');
+        expect(method.type.typeName).toEqual('refAlias');
+        const alias = method.type as RefAliasType;
+        expect(alias.refName).toEqual('NeverBranch');
+        expect(alias.type.typeName).toEqual('never');
+    });
+
+    it('should preserve never in union members (metadata fidelity)', () => {
+        const method = getMethod('cleanUnion');
+        // The metadata layer faithfully preserves the union AST structure.
+        // `string | never` is stored as a union with both members.
+        // Simplification (stripping never) happens in the swagger layer.
+        expect(method.type.typeName).toEqual('refAlias');
+        const alias = method.type as RefAliasType;
+        expect(alias.refName).toEqual('CleanUnion');
+        expect(alias.type.typeName).toEqual('union');
+        const union = alias.type as UnionType;
+        expect(union.members).toHaveLength(2);
+        expect(union.members.map((m) => m.typeName).sort()).toEqual(['never', 'string']);
+    });
+});

--- a/packages/metadata/test/unit/generator/parameters.spec.ts
+++ b/packages/metadata/test/unit/generator/parameters.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { Controller, Metadata } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -24,7 +24,7 @@ describe('parameter metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/reference-types.spec.ts
+++ b/packages/metadata/test/unit/generator/reference-types.spec.ts
@@ -13,7 +13,7 @@ import {
 } from 'vitest';
 import jsonata from 'jsonata';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import { generateMetadata } from '../../../src';
 import type {
     ArrayType, 
@@ -32,7 +32,7 @@ describe('check referenceTypes', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/responses.spec.ts
+++ b/packages/metadata/test/unit/generator/responses.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { Controller, Metadata } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -25,7 +25,7 @@ describe('response metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/security.spec.ts
+++ b/packages/metadata/test/unit/generator/security.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { Controller, Metadata } from '../../../src';
 import { generateMetadata } from '../../../src';
 
@@ -24,7 +24,7 @@ describe('security metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/metadata/test/unit/generator/utility-types.spec.ts
+++ b/packages/metadata/test/unit/generator/utility-types.spec.ts
@@ -12,7 +12,7 @@ import {
     it,
 } from 'vitest';
 import path from 'node:path';
-import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type {
     Metadata,
     NestedObjectLiteralType,
@@ -29,7 +29,7 @@ describe('utility type metadata extraction', () => {
     beforeAll(async () => {
         metadata = await generateMetadata({
             entryPoint: [{
-                cwd: path.join(process.cwd(), '..', 'decorators'),
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
                 pattern: './test/data/controllers/**/*.ts',
             }],
             cache: false,

--- a/packages/swagger/src/generator/abstract.ts
+++ b/packages/swagger/src/generator/abstract.ts
@@ -33,6 +33,7 @@ import {
     isEnumType,
     isIntersectionType,
     isNestedObjectLiteralType,
+    isNeverType,
     isPrimitiveType,
     isReferenceType,
     isTupleType,
@@ -144,7 +145,7 @@ export abstract class AbstractSpecGenerator<Spec extends SpecV2 | SpecV3, Schema
     }
 
     protected getSchemaForType(type: BaseType): Schema | BaseSchema<Schema> {
-        if (isVoidType(type) || isUndefinedType(type)) {
+        if (isVoidType(type) || isUndefinedType(type) || isNeverType(type)) {
             return {} as Schema;
         } if (isReferenceType(type)) {
             return this.getSchemaForReferenceType(type);

--- a/packages/swagger/src/generator/v2/module.ts
+++ b/packages/swagger/src/generator/v2/module.ts
@@ -22,6 +22,7 @@ import {
     isAnyType,
     isBinaryType,
     isEnumType,
+    isNeverType,
     isRefEnumType,
     isRefObjectType,
     isUndefinedType,
@@ -505,6 +506,7 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
             if (
                 !isAnyType(member) &&
                 !isUndefinedType(member) &&
+                !isNeverType(member) &&
                 !isEnumType(member)
             ) {
                 members.push(member);
@@ -554,7 +556,8 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
 
             if (
                 res.schema &&
-                !isVoidType(res.schema)
+                !isVoidType(res.schema) &&
+                !isNeverType(res.schema)
             ) {
                 if (res.produces) {
                     produces.push(...res.produces);

--- a/packages/swagger/src/generator/v3/module.ts
+++ b/packages/swagger/src/generator/v3/module.ts
@@ -28,6 +28,7 @@ import {
     isEnumType,
     isIntersectionType,
     isNestedObjectLiteralType,
+    isNeverType,
     isRefAliasType,
     isRefObjectType,
     isUndefinedType,
@@ -326,7 +327,8 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
 
             if (
                 res.schema &&
-                !isVoidType(res.schema)
+                !isVoidType(res.schema) &&
+                !isNeverType(res.schema)
             ) {
                 const examples : Record<string, Example> = {};
                 if (
@@ -590,6 +592,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
             if (
                 !isAnyType(member) &&
                 !isUndefinedType(member) &&
+                !isNeverType(member) &&
                 !isEnumType(member)
             ) {
                 members.push(member);

--- a/packages/swagger/test/helpers/metadata-builder.ts
+++ b/packages/swagger/test/helpers/metadata-builder.ts
@@ -161,6 +161,10 @@ export function voidType(): Type {
     return { typeName: 'void' };
 }
 
+export function neverType(): Type {
+    return { typeName: 'never' };
+}
+
 export function stringType(): Type {
     return { typeName: 'string' };
 }

--- a/packages/swagger/test/unit/specification/never-type.spec.ts
+++ b/packages/swagger/test/unit/specification/never-type.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { SpecV2, SpecV3 } from '../../../src';
+import { Version, generate } from '../../../src';
+import {
+    createController,
+    createMetadata,
+    createMethod,
+    createProperty,
+    createRefObject,
+    createResponse,
+    neverType,
+    refObjectType,
+    stringType,
+    unionType,
+} from '../../helpers/metadata-builder';
+
+describe('never type in swagger output (#778)', () => {
+    let specV2: SpecV2;
+    let specV3: SpecV3;
+
+    const referenceTypes = {
+        User: createRefObject('User', [
+            createProperty({ name: 'id', type: { typeName: 'integer' } }),
+            createProperty({ name: 'name', type: stringType() }),
+        ]),
+    };
+
+    const metadata = createMetadata(
+        [
+            createController({
+                name: 'NeverController',
+                path: 'never',
+                methods: [
+                    createMethod({
+                        name: 'alwaysThrows',
+                        method: 'get',
+                        path: 'throws',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: neverType(),
+                            }),
+                        ],
+                        type: neverType(),
+                    }),
+                    createMethod({
+                        name: 'unionWithNever',
+                        method: 'get',
+                        path: 'union',
+                        responses: [
+                            createResponse({
+                                status: '200',
+                                description: 'Success',
+                                schema: unionType([
+                                    refObjectType('User'),
+                                    neverType(),
+                                    stringType(),
+                                ]),
+                            }),
+                        ],
+                        type: unionType([
+                            refObjectType('User'),
+                            neverType(),
+                            stringType(),
+                        ]),
+                    }),
+                ],
+            }),
+        ],
+        referenceTypes,
+    );
+
+    beforeAll(async () => {
+        specV2 = await generate({
+            version: Version.V2,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+
+        specV3 = await generate({
+            version: Version.V3,
+            options: {
+                output: false,
+                servers: 'http://localhost:3000/',
+                metadata,
+            },
+        });
+    });
+
+    describe('standalone never type', () => {
+        it('V3: should produce no response body for never return type', () => {
+            const response = specV3.paths['/never/throws'].get!.responses['200'];
+            expect(response.description).toEqual('Success');
+            expect(response).not.toHaveProperty('content');
+        });
+
+        it('V2: should produce no response body for never return type', () => {
+            const response = specV2.paths['/never/throws'].get!.responses['200'];
+            expect(response.description).toEqual('Success');
+            expect(response).not.toHaveProperty('schema');
+        });
+    });
+
+    describe('union containing never', () => {
+        it('V3: should filter never from union members', () => {
+            const { schema } = specV3.paths['/never/union'].get!.responses['200'].content['application/json'];
+            // never is filtered out, leaving User (object) + string (primitive)
+            // mixed union → anyOf
+            expect(schema).toHaveProperty('anyOf');
+            expect(schema.anyOf).toHaveLength(2);
+        });
+
+        it('V2: should filter never from union members', () => {
+            const response = specV2.paths['/never/union'].get!.responses['200'];
+            // V2 handles mixed unions as object type
+            expect(response.schema).toBeDefined();
+            expect(response.schema).not.toHaveProperty('oneOf');
+        });
+    });
+});


### PR DESCRIPTION
closes #778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for TypeScript `never` in metadata and Swagger/OpenAPI generation.
  * Endpoints returning `never` now produce no response schema/content.

* **Behavioral Changes**
  * `never` members are filtered out of unions in generated API docs.

* **Tests**
  * Added unit tests validating `never` handling and updated test setups for consistent path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->