### PR TITLE
feat(metadata,decorators): v2 orchestrator and @trapi/decorators preset

### DIFF
--- a/packages/decorators/src/index.ts
+++ b/packages/decorators/src/index.ts
@@ -9,5 +9,8 @@ import { schema } from './module';
 
 export * from './decorators';
 export * from './module';
+export * from './preset';
 
+// Default export remains the v1 schema until generateMetadata is migrated to v2 (Phase 3).
+// The v2 preset is exported by name as `preset` and will become the default at cutover.
 export default schema;

--- a/packages/decorators/src/preset.ts
+++ b/packages/decorators/src/preset.ts
@@ -1,0 +1,591 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    type ControllerDraft,
+    type DecoratorArgument,
+    type HandlerContext,
+    type MethodDraft,
+    type MethodHandler,
+    ParamKind,
+    type ParameterDraft,
+    type ParameterHandler,
+    type Preset,
+    append,
+    controller,
+    controllerJsDoc,
+    method,
+    methodJsDoc,
+    parameter,
+    parameterJsDoc,
+} from '@trapi/metadata';
+
+// -----------------------------------------------------------------------------
+// Shared apply helpers (used by handlers that target both class and method)
+// -----------------------------------------------------------------------------
+
+const setHidden = (_ctx: HandlerContext, draft: { hidden: boolean }) => {
+    draft.hidden = true;
+};
+
+const setDeprecated = (_ctx: HandlerContext, draft: { deprecated?: boolean }) => {
+    draft.deprecated = true;
+};
+
+const appendTags = append('tags').positionalAll();
+const appendProduces = append('produces').positionalAll();
+const appendConsumes = append('consumes').positionalAll();
+
+function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+function readNumber(arg: DecoratorArgument | undefined): number | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'number') return arg.raw;
+    return undefined;
+}
+
+// -----------------------------------------------------------------------------
+// Controller / class handlers
+// -----------------------------------------------------------------------------
+
+const controllerControllerHandler = controller({
+    match: { name: 'Controller', on: 'class' },
+    apply: (ctx, draft) => {
+        const path = readString(ctx.argument(0));
+        draft.path = path ?? '';
+    },
+});
+
+const controllerMountHandler = controller({
+    match: { name: 'Mount', on: 'class' },
+    apply: (ctx, draft) => {
+        const path = readString(ctx.argument(0));
+        if (path !== undefined) {
+            draft.path = path;
+        }
+    },
+});
+
+const controllerHiddenHandler = controller({
+    match: { name: 'Hidden', on: 'class' },
+    apply: setHidden,
+});
+
+const controllerTagsHandler = controller({
+    match: { name: 'Tags', on: 'class' },
+    apply: appendTags,
+});
+
+const controllerProducesHandler = controller({
+    match: { name: 'Produces', on: 'class' },
+    apply: appendProduces,
+});
+
+const controllerConsumesHandler = controller({
+    match: { name: 'Consumes', on: 'class' },
+    apply: appendConsumes,
+});
+
+const controllerAcceptHandler = controller({
+    match: { name: 'Accept', on: 'class' },
+    apply: appendConsumes,
+});
+
+const controllerSecurityHandler = controller({
+    match: { name: 'Security', on: 'class' },
+    apply: (ctx, draft) => appendSecurityToDraft(ctx, draft),
+});
+
+const controllerExtensionHandler = controller({
+    match: { name: 'Extension', on: 'class' },
+    apply: (ctx, draft) => appendExtensionToDraft(ctx, draft),
+});
+
+// -----------------------------------------------------------------------------
+// Method handlers
+// -----------------------------------------------------------------------------
+
+function setVerbAndPath(verb: MethodDraft['verb']): MethodHandler['apply'] {
+    return (ctx, draft) => {
+        draft.verb = verb;
+        const path = readString(ctx.argument(0));
+        if (path !== undefined) {
+            draft.path = path;
+        }
+    };
+}
+
+const methodGetHandler = method({ match: { name: 'Get', on: 'method' }, apply: setVerbAndPath('get') });
+const methodPostHandler = method({ match: { name: 'Post', on: 'method' }, apply: setVerbAndPath('post') });
+const methodPutHandler = method({ match: { name: 'Put', on: 'method' }, apply: setVerbAndPath('put') });
+const methodDeleteHandler = method({ match: { name: 'Delete', on: 'method' }, apply: setVerbAndPath('delete') });
+const methodPatchHandler = method({ match: { name: 'Patch', on: 'method' }, apply: setVerbAndPath('patch') });
+const methodOptionsHandler = method({ match: { name: 'Options', on: 'method' }, apply: setVerbAndPath('options') });
+const methodHeadHandler = method({ match: { name: 'Head', on: 'method' }, apply: setVerbAndPath('head') });
+// `All` maps to `get` for OpenAPI purposes (closest analogue) — same as v1 behaviour.
+const methodAllHandler = method({
+    match: { name: 'All', on: 'method' },
+    apply: (ctx, draft) => {
+        draft.verb = 'get';
+        const path = readString(ctx.argument(0));
+        if (path !== undefined) {
+            draft.path = path;
+        }
+    },
+});
+
+const methodMountHandler = method({
+    match: { name: 'Mount', on: 'method' },
+    apply: (ctx, draft) => {
+        const path = readString(ctx.argument(0));
+        if (path !== undefined) {
+            draft.path = path;
+        }
+    },
+});
+
+const methodHiddenHandler = method({
+    match: { name: 'Hidden', on: 'method' },
+    apply: setHidden,
+});
+
+const methodDeprecatedHandler = method({
+    match: { name: 'Deprecated', on: 'method' },
+    apply: setDeprecated,
+});
+
+const methodTagsHandler = method({
+    match: { name: 'Tags', on: 'method' },
+    apply: appendTags,
+});
+
+const methodProducesHandler = method({
+    match: { name: 'Produces', on: 'method' },
+    apply: appendProduces,
+});
+
+const methodConsumesHandler = method({
+    match: { name: 'Consumes', on: 'method' },
+    apply: appendConsumes,
+});
+
+const methodAcceptHandler = method({
+    match: { name: 'Accept', on: 'method' },
+    apply: appendConsumes,
+});
+
+const methodSecurityHandler = method({
+    match: { name: 'Security', on: 'method' },
+    apply: (ctx, draft) => appendSecurityToDraft(ctx, draft),
+});
+
+const methodExtensionHandler = method({
+    match: { name: 'Extension', on: 'method' },
+    apply: (ctx, draft) => appendExtensionToDraft(ctx, draft),
+});
+
+const methodDescriptionHandler = method({
+    match: { name: 'Description', on: 'method' },
+    apply: (ctx, draft) => {
+        const status = readString(ctx.argument(0)) ?? String(readNumber(ctx.argument(0)) ?? '200');
+        const description = readString(ctx.argument(1)) ?? 'Ok';
+        const payload = ctx.argument(2);
+        const examples = payload && payload.kind !== 'unresolvable' ?
+            [{ value: payload.raw }] :
+            [];
+        const typeArg = ctx.typeArgument(0);
+        draft.responses.push({
+            name: status,
+            status,
+            description,
+            examples,
+            schema: typeArg ? typeArg.resolve() : undefined,
+        });
+    },
+});
+
+const methodExampleHandler = method({
+    match: { name: 'Example', on: 'method' },
+    apply: (ctx, draft) => {
+        const payload = ctx.argument(0);
+        if (!payload || payload.kind === 'unresolvable') {
+            return;
+        }
+        const label = readString(ctx.argument(1));
+        // Stash example on the draft via extensions until the orchestrator merges it
+        // into the default 200-response.
+        draft.extensions.push({
+            key: '__trapi_example__',
+            value: { value: payload.raw, label } as never,
+        });
+    },
+});
+
+// -----------------------------------------------------------------------------
+// Parameter handlers
+// -----------------------------------------------------------------------------
+
+function claimParameter(
+    kind: typeof ParamKind[keyof typeof ParamKind],
+    namedKind?: typeof ParamKind[keyof typeof ParamKind],
+): ParameterHandler['apply'] {
+    return (ctx, draft) => {
+        const argName = readString(ctx.argument(0));
+        if (argName !== undefined && namedKind) {
+            draft.in = namedKind;
+            draft.name = argName;
+        } else {
+            draft.in = kind;
+            if (argName !== undefined) {
+                draft.name = argName;
+            }
+        }
+    };
+}
+
+const parameterBodyHandler = parameter({
+    match: { name: 'Body', on: 'parameter' },
+    apply: claimParameter(ParamKind.Body, ParamKind.BodyProp),
+});
+
+const parameterBodyPropHandler = parameter({
+    match: { name: 'BodyProp', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.BodyProp;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterQueryHandler = parameter({
+    match: { name: 'Query', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        if (name !== undefined) {
+            draft.in = ParamKind.Query;
+            draft.name = name;
+        } else {
+            draft.in = ParamKind.QueryProp;
+        }
+    },
+});
+
+const parameterQueryPropHandler = parameter({
+    match: { name: 'QueryProp', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.QueryProp;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterPathHandler = parameter({
+    match: { name: 'Path', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.Path;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterPathParamHandler = parameter({
+    match: { name: 'PathParam', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.Path;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterPathParamsHandler = parameter({
+    match: { name: 'PathParams', on: 'parameter' },
+    apply: (_ctx, draft) => {
+        draft.in = ParamKind.Path;
+    },
+});
+
+const parameterCookieHandler = parameter({
+    match: { name: 'Cookie', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.Cookie;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterCookiesHandler = parameter({
+    match: { name: 'Cookies', on: 'parameter' },
+    apply: (_ctx, draft) => {
+        draft.in = ParamKind.Cookie;
+    },
+});
+
+const parameterHeaderHandler = parameter({
+    match: { name: 'Header', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.Header;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterHeadersHandler = parameter({
+    match: { name: 'Headers', on: 'parameter' },
+    apply: (_ctx, draft) => {
+        draft.in = ParamKind.Header;
+    },
+});
+
+const parameterFormHandler = parameter({
+    match: { name: 'Form', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.FormData;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterFormPropHandler = parameter({
+    match: { name: 'FormProp', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.FormData;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterFileHandler = parameter({
+    match: { name: 'File', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.FormData;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterFilesHandler = parameter({
+    match: { name: 'Files', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.FormData;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterParamHandler = parameter({
+    match: { name: 'Param', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        draft.in = ParamKind.Path;
+        if (name) draft.name = name;
+    },
+});
+
+const parameterParamsHandler = parameter({
+    match: { name: 'Params', on: 'parameter' },
+    apply: (_ctx, draft) => {
+        draft.in = ParamKind.Path;
+    },
+});
+
+const parameterContextHandler = parameter({
+    match: { name: 'Context', on: 'parameter' },
+    apply: (_ctx, draft) => {
+        draft.in = ParamKind.Context;
+    },
+});
+
+const parameterExtensionHandler = parameter({
+    match: { name: 'Extension', on: 'parameter' },
+    apply: (ctx, draft) => appendExtensionToDraft(ctx, draft),
+});
+
+// Numeric type-narrowing handlers store an intent on validators; the orchestrator
+// (or swagger emitter) consumes them when shaping the parameter's emitted type.
+function numericValidator(kind: 'int' | 'long' | 'float' | 'double'): ParameterHandler['apply'] {
+    return (_ctx, draft) => {
+        draft.validators[`is${kind[0].toUpperCase()}${kind.slice(1)}`] = { value: kind };
+    };
+}
+
+const parameterIsIntHandler = parameter({
+    match: { name: 'IsInt', on: 'parameter' },
+    apply: numericValidator('int'),
+});
+const parameterIsLongHandler = parameter({
+    match: { name: 'IsLong', on: 'parameter' },
+    apply: numericValidator('long'),
+});
+const parameterIsFloatHandler = parameter({
+    match: { name: 'IsFloat', on: 'parameter' },
+    apply: numericValidator('float'),
+});
+const parameterIsDoubleHandler = parameter({
+    match: { name: 'IsDouble', on: 'parameter' },
+    apply: numericValidator('double'),
+});
+
+// -----------------------------------------------------------------------------
+// JSDoc handlers
+// -----------------------------------------------------------------------------
+
+const methodHiddenJsDoc = methodJsDoc({
+    match: { tag: 'hidden' },
+    apply: (_ctx, draft) => { draft.hidden = true; },
+});
+
+const methodDeprecatedJsDoc = methodJsDoc({
+    match: { tag: 'deprecated' },
+    apply: (_ctx, draft) => { draft.deprecated = true; },
+});
+
+const methodSummaryJsDoc = methodJsDoc({
+    match: { tag: 'summary' },
+    apply: (ctx, draft) => {
+        if (ctx.source.text) draft.summary = ctx.source.text;
+    },
+});
+
+const controllerHiddenJsDoc = controllerJsDoc({
+    match: { tag: 'hidden' },
+    apply: (_ctx, draft) => { draft.hidden = true; },
+});
+
+const parameterDeprecatedJsDoc = parameterJsDoc({
+    match: { tag: 'deprecated' },
+    apply: (_ctx, draft) => { draft.deprecated = true; },
+});
+
+// -----------------------------------------------------------------------------
+// Shared draft mutators (defined out-of-order to keep the handler list readable)
+// -----------------------------------------------------------------------------
+
+function appendSecurityToDraft(
+    ctx: HandlerContext,
+    draft: ControllerDraft | MethodDraft,
+): void {
+    const scopesArg = ctx.argument(0);
+    const nameArg = ctx.argument(1);
+
+    let name = readString(nameArg);
+    if (!name) {
+        const obj = scopesArg?.kind === 'object' ? scopesArg.raw : undefined;
+        if (obj && typeof obj === 'object') {
+            // @Security({ schemeName: ['scope'] }) form
+            const security: Record<string, string[]> = {};
+            for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+                if (Array.isArray(val) && val.every((v) => typeof v === 'string')) {
+                    security[key] = val;
+                }
+            }
+            if (Object.keys(security).length > 0) {
+                draft.security ??= [];
+                draft.security.push(security);
+                return;
+            }
+        }
+        name = 'default';
+    }
+
+    const scopes: string[] = [];
+    if (scopesArg?.kind === 'array' && Array.isArray(scopesArg.raw)) {
+        for (const item of scopesArg.raw) {
+            if (typeof item === 'string') scopes.push(item);
+        }
+    } else if (scopesArg?.kind === 'literal' && typeof scopesArg.raw === 'string') {
+        scopes.push(scopesArg.raw);
+    }
+
+    draft.security ??= [];
+    draft.security.push({ [name]: scopes });
+}
+
+function appendExtensionToDraft(
+    ctx: HandlerContext,
+    draft: ControllerDraft | MethodDraft | ParameterDraft,
+): void {
+    const keyArg = ctx.argument(0);
+    const valueArg = ctx.argument(1);
+    const key = readString(keyArg);
+    if (!key || !valueArg) {
+        return;
+    }
+    draft.extensions.push({ key, value: valueArg.raw as never });
+}
+
+// -----------------------------------------------------------------------------
+// Assembled preset
+// -----------------------------------------------------------------------------
+
+export const preset: Preset = {
+    name: '@trapi/decorators',
+    controllers: [
+        controllerControllerHandler,
+        controllerMountHandler,
+        controllerHiddenHandler,
+        controllerTagsHandler,
+        controllerProducesHandler,
+        controllerConsumesHandler,
+        controllerAcceptHandler,
+        controllerSecurityHandler,
+        controllerExtensionHandler,
+    ],
+    methods: [
+        methodGetHandler,
+        methodPostHandler,
+        methodPutHandler,
+        methodDeleteHandler,
+        methodPatchHandler,
+        methodOptionsHandler,
+        methodHeadHandler,
+        methodAllHandler,
+        methodMountHandler,
+        methodHiddenHandler,
+        methodDeprecatedHandler,
+        methodTagsHandler,
+        methodProducesHandler,
+        methodConsumesHandler,
+        methodAcceptHandler,
+        methodSecurityHandler,
+        methodExtensionHandler,
+        methodDescriptionHandler,
+        methodExampleHandler,
+    ],
+    parameters: [
+        parameterBodyHandler,
+        parameterBodyPropHandler,
+        parameterQueryHandler,
+        parameterQueryPropHandler,
+        parameterPathHandler,
+        parameterPathParamHandler,
+        parameterPathParamsHandler,
+        parameterCookieHandler,
+        parameterCookiesHandler,
+        parameterHeaderHandler,
+        parameterHeadersHandler,
+        parameterFormHandler,
+        parameterFormPropHandler,
+        parameterFileHandler,
+        parameterFilesHandler,
+        parameterParamHandler,
+        parameterParamsHandler,
+        parameterContextHandler,
+        parameterExtensionHandler,
+        parameterIsIntHandler,
+        parameterIsLongHandler,
+        parameterIsFloatHandler,
+        parameterIsDoubleHandler,
+    ],
+    controllerJsDoc: [controllerHiddenJsDoc],
+    methodJsDoc: [methodHiddenJsDoc, methodDeprecatedJsDoc, methodSummaryJsDoc],
+    parameterJsDoc: [parameterDeprecatedJsDoc],
+};

--- a/packages/decorators/src/preset.ts
+++ b/packages/decorators/src/preset.ts
@@ -221,11 +221,14 @@ const methodExampleHandler = method({
             return;
         }
         const label = readString(ctx.argument(1));
+        const value = label === undefined ?
+            { value: payload.raw } :
+            { value: payload.raw, label };
         // Stash example on the draft via extensions until the orchestrator merges it
         // into the default 200-response.
         draft.extensions.push({
             key: '__trapi_example__',
-            value: { value: payload.raw, label } as never,
+            value: value as never,
         });
     },
 });
@@ -268,15 +271,7 @@ const parameterBodyPropHandler = parameter({
 
 const parameterQueryHandler = parameter({
     match: { name: 'Query', on: 'parameter' },
-    apply: (ctx, draft) => {
-        const name = readString(ctx.argument(0));
-        if (name !== undefined) {
-            draft.in = ParamKind.Query;
-            draft.name = name;
-        } else {
-            draft.in = ParamKind.QueryProp;
-        }
-    },
+    apply: claimParameter(ParamKind.Query, ParamKind.QueryProp),
 });
 
 const parameterQueryPropHandler = parameter({
@@ -516,7 +511,12 @@ function appendExtensionToDraft(
     const keyArg = ctx.argument(0);
     const valueArg = ctx.argument(1);
     const key = readString(keyArg);
-    if (!key || !valueArg) {
+    if (
+        !key ||
+        !valueArg ||
+        valueArg.kind === 'unresolvable' ||
+        typeof valueArg.raw === 'undefined'
+    ) {
         return;
     }
     draft.extensions.push({ key, value: valueArg.raw as never });

--- a/packages/metadata/src/adapters/decorator/index.ts
+++ b/packages/metadata/src/adapters/decorator/index.ts
@@ -8,3 +8,4 @@
 export * from './resolver';
 export * from './property-manager';
 export * from './preset';
+export * from './v2';

--- a/packages/metadata/src/adapters/decorator/v2/orchestrator/index.ts
+++ b/packages/metadata/src/adapters/decorator/v2/orchestrator/index.ts
@@ -5,10 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './constants';
 export * from './module';
-export * from './orchestrator';
 export * from './types';
-export * from './typescript';
-export * from './utils';
-export * from './validation';

--- a/packages/metadata/src/adapters/decorator/v2/orchestrator/module.ts
+++ b/packages/metadata/src/adapters/decorator/v2/orchestrator/module.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Node } from 'typescript';
+import { matches, matchesJsDoc } from '../utils';
+import type {
+    DecoratorSource,
+    HandlerContext,
+    JsDocHandlerContext,
+    JsDocMatch,
+    JsDocSource,
+    Match,
+} from '../types';
+import { buildDecoratorSources, buildJsDocSources } from '../typescript';
+import type { ApplyHandlersOptions } from './types';
+
+type DecoratorHandlerLike<D> = {
+    match: Match;
+    apply: (ctx: HandlerContext, draft: D) => void;
+};
+
+type JsDocHandlerLike<D> = {
+    match: JsDocMatch;
+    apply: (ctx: JsDocHandlerContext, draft: D) => void;
+};
+
+export function buildHandlerContext(
+    source: DecoratorSource,
+    options: ApplyHandlersOptions,
+): HandlerContext {
+    return {
+        host: source.host,
+        argument: (i) => source.arguments[i],
+        arguments: () => source.arguments,
+        typeArgument: (i) => source.typeArguments[i],
+        typeArguments: () => source.typeArguments,
+        parameterType: options.parameterType ?? (() => undefined),
+    };
+}
+
+export function buildJsDocHandlerContext(
+    source: JsDocSource,
+    options: ApplyHandlersOptions,
+): JsDocHandlerContext {
+    return {
+        host: source.host,
+        source,
+        parameterType: options.parameterType ?? (() => undefined),
+    };
+}
+
+export function applyDecoratorHandlers<D>(
+    node: Node,
+    handlers: DecoratorHandlerLike<D>[],
+    draft: D,
+    options: ApplyHandlersOptions,
+): void {
+    if (handlers.length === 0) {
+        return;
+    }
+    const sources = buildDecoratorSources(node, options);
+    if (sources.length === 0) {
+        return;
+    }
+    for (const source of sources) {
+        for (const handler of handlers) {
+            if (matches(handler.match, source)) {
+                handler.apply(buildHandlerContext(source, options), draft);
+            }
+        }
+    }
+}
+
+export function applyJsDocHandlers<D>(
+    node: Node,
+    handlers: JsDocHandlerLike<D>[],
+    draft: D,
+    options: ApplyHandlersOptions,
+): void {
+    if (handlers.length === 0) {
+        return;
+    }
+    const sources = buildJsDocSources(node, options);
+    if (sources.length === 0) {
+        return;
+    }
+    for (const source of sources) {
+        for (const handler of handlers) {
+            if (matchesJsDoc(handler.match, source)) {
+                handler.apply(buildJsDocHandlerContext(source, options), draft);
+            }
+        }
+    }
+}

--- a/packages/metadata/src/adapters/decorator/v2/orchestrator/types.ts
+++ b/packages/metadata/src/adapters/decorator/v2/orchestrator/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { TypeChecker, TypeNode } from 'typescript';
+import type { Type } from '../../../../core/resolver/types';
+import type { DecoratorHost, DecoratorTarget } from '../types';
+
+export type ApplyHandlersOptions = {
+    target: DecoratorTarget;
+    host: DecoratorHost;
+    resolveTypeNode: (node: TypeNode) => Type;
+    parameterType?: () => Type | undefined;
+    typeChecker?: TypeChecker;
+};

--- a/packages/metadata/src/app/generator/parameter/handler/types.ts
+++ b/packages/metadata/src/app/generator/parameter/handler/types.ts
@@ -6,8 +6,6 @@
  */
 
 import type * as ts from 'typescript';
-import type { DecoratorID } from '../../../../core/types/decorator-id';
-import type { DecoratorPropertyManager } from '../../../../adapters/decorator/property-manager';
 import type {
     BaseType,
     NestedObjectLiteralType,
@@ -45,11 +43,3 @@ export interface IParameterHandlerContext {
         details: Omit<Partial<Parameter>, 'in'> & { in: `${ParameterSource}` },
     ): Parameter[];
 }
-
-/**
- * Type for parameter source handlers.
- */
-export type ParameterHandler = (
-    ctx: IParameterHandlerContext,
-    manager: DecoratorPropertyManager<`${DecoratorID}`>,
-) => Parameter[];

--- a/packages/metadata/test/unit/decorator/v2/orchestrator.spec.ts
+++ b/packages/metadata/test/unit/decorator/v2/orchestrator.spec.ts
@@ -202,19 +202,57 @@ describe('applyJsDocHandlers', () => {
         expect(seen).toEqual(['short text']);
     });
 
-    it('passes the parameterType callback through', () => {
-        const sf = compile('class C {}');
+    it('exposes the parameterType callback on JsDocHandlerContext', () => {
+        const sf = compile(`
+            /**
+             * @description short text
+             */
+            class C {}
+        `);
         const node = findClass(sf, 'C');
-        const draft = newMethodDraft({ name: 'list' });
-        const handlers: MethodHandler[] = [];
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        let resolved: Type | undefined;
+        const handlers: ControllerJsDocHandler[] = [
+            {
+                match: { tag: 'description' },
+                apply: (ctx) => { resolved = ctx.parameterType(); },
+            },
+        ];
 
-        applyDecoratorHandlers(node, handlers, draft, {
-            target: 'method',
-            host: { name: 'list' },
+        applyJsDocHandlers(node, handlers, draft, {
+            target: 'class',
+            host: { name: 'C' },
             resolveTypeNode: stubResolveTypeNode,
             parameterType: () => ({ typeName: 'string' } as Type),
         });
-        // No assertion target — covers the parameterType wiring path without runtime crash.
-        expect(draft.parameters).toEqual([]);
+        expect(resolved).toEqual({ typeName: 'string' });
+    });
+});
+
+describe('applyDecoratorHandlers — parameterType wiring', () => {
+    it('passes the parameterType callback through to handlers', () => {
+        const sf = compile(`
+            class C {
+                @Get() list() {}
+            }
+        `);
+        const cls = findClass(sf, 'C');
+        const method = cls.members[0] as ts.MethodDeclaration;
+        const draft = newMethodDraft({ name: 'list' });
+        let observed: Type | undefined;
+        const handlers: MethodHandler[] = [
+            {
+                match: { name: 'Get' },
+                apply: (ctx) => { observed = ctx.parameterType(); },
+            },
+        ];
+
+        applyDecoratorHandlers(method, handlers, draft, {
+            target: 'method',
+            host: { name: 'list', parentName: 'C' },
+            resolveTypeNode: stubResolveTypeNode,
+            parameterType: () => ({ typeName: 'string' } as Type),
+        });
+        expect(observed).toEqual({ typeName: 'string' });
     });
 });

--- a/packages/metadata/test/unit/decorator/v2/orchestrator.spec.ts
+++ b/packages/metadata/test/unit/decorator/v2/orchestrator.spec.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+import {
+    type ApplyHandlersOptions,
+    type ControllerDraft,
+    type ControllerHandler,
+    type ControllerJsDocHandler,
+    type MethodHandler,
+    applyDecoratorHandlers,
+    applyJsDocHandlers,
+    newControllerDraft,
+    newMethodDraft,
+} from '../../../../src/adapters/decorator/v2';
+import type { Type } from '../../../../src/core/resolver/types';
+
+function compile(source: string): ts.SourceFile {
+    return ts.createSourceFile('sample.ts', source, ts.ScriptTarget.Latest, true);
+}
+
+function findClass(sf: ts.SourceFile, name: string): ts.ClassDeclaration {
+    const found = sf.statements.find(
+        (s): s is ts.ClassDeclaration => ts.isClassDeclaration(s) && s.name?.text === name,
+    );
+    if (!found) throw new Error(`class ${name} not found`);
+    return found;
+}
+
+const stubResolveTypeNode = (): Type => ({ typeName: 'any' } as Type);
+
+function options(host: string, target: 'class' | 'method' | 'parameter' = 'class'): ApplyHandlersOptions {
+    return {
+        target,
+        host: { name: host },
+        resolveTypeNode: stubResolveTypeNode,
+    };
+}
+
+describe('applyDecoratorHandlers', () => {
+    it('applies a matching handler to the draft', () => {
+        const sf = compile(`
+            @Controller("/users")
+            class UsersController {}
+        `);
+        const node = findClass(sf, 'UsersController');
+        const draft = newControllerDraft({ name: 'UsersController', location: 'sample.ts' });
+        const handlers: ControllerHandler[] = [
+            {
+                match: { name: 'Controller' },
+                apply: (ctx, d) => {
+                    const arg = ctx.argument(0);
+                    if (arg && arg.kind === 'literal') {
+                        d.path = arg.raw as string;
+                    }
+                },
+            },
+        ];
+
+        applyDecoratorHandlers(node, handlers, draft, options('UsersController'));
+        expect(draft.path).toEqual('/users');
+    });
+
+    it('skips when no handler matches', () => {
+        const sf = compile('@Other() class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const handlers: ControllerHandler[] = [
+            { match: { name: 'Controller' }, apply: () => { throw new Error('should not run'); } },
+        ];
+
+        applyDecoratorHandlers(node, handlers, draft, options('C'));
+        expect(draft.path).toBeUndefined();
+    });
+
+    it('runs all matching handlers in registry order (additive)', () => {
+        const sf = compile('@Controller() class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const trace: string[] = [];
+        const handlers: ControllerHandler[] = [
+            { match: { name: 'Controller' }, apply: () => { trace.push('a'); } },
+            { match: { name: 'Controller' }, apply: () => { trace.push('b'); } },
+        ];
+
+        applyDecoratorHandlers(node, handlers, draft, options('C'));
+        expect(trace).toEqual(['a', 'b']);
+    });
+
+    it('respects match.on filter', () => {
+        const sf = compile('@Body() class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const trace: string[] = [];
+        const handlers: ControllerHandler[] = [
+            { match: { name: 'Body', on: 'parameter' }, apply: () => { trace.push('param'); } },
+            { match: { name: 'Body' }, apply: () => { trace.push('any'); } },
+        ];
+
+        applyDecoratorHandlers(node, handlers, draft, options('C'));
+        expect(trace).toEqual(['any']);
+    });
+
+    it('exposes ctx.argument and ctx.typeArgument from sources', () => {
+        const sf = compile(`
+            class C {
+                @Get<MyType>("/path", { extra: 1 })
+                list() {}
+            }
+        `);
+        const cls = findClass(sf, 'C');
+        const method = cls.members[0] as ts.MethodDeclaration;
+        const draft = newMethodDraft({ name: 'list' });
+        const handlers: MethodHandler[] = [
+            {
+                match: { name: 'Get' },
+                apply: (ctx, d) => {
+                    const path = ctx.argument(0);
+                    const opts = ctx.argument(1);
+                    const ta = ctx.typeArgument(0);
+                    if (path?.kind === 'literal') d.path = path.raw as string;
+                    if (opts?.kind === 'object') d.extensions.push({ key: 'first-arg', value: opts.raw as never });
+                    if (ta) d.extensions.push({ key: 'type-arg', value: 'present' });
+                },
+            },
+        ];
+
+        applyDecoratorHandlers(method, handlers, draft, {
+            target: 'method',
+            host: { name: 'list', parentName: 'C' },
+            resolveTypeNode: stubResolveTypeNode,
+        });
+
+        expect(draft.path).toEqual('/path');
+        expect(draft.extensions).toContainEqual({ key: 'first-arg', value: { extra: 1 } });
+        expect(draft.extensions).toContainEqual({ key: 'type-arg', value: 'present' });
+    });
+
+    it('does nothing when handlers array is empty', () => {
+        const sf = compile('@Controller() class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+
+        applyDecoratorHandlers(node, [], draft, options('C'));
+        expect(draft.path).toBeUndefined();
+    });
+
+    it('does nothing when node has no decorators', () => {
+        const sf = compile('class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const handlers: ControllerHandler[] = [
+            { match: { name: 'Controller' }, apply: () => { throw new Error('should not run'); } },
+        ];
+
+        applyDecoratorHandlers(node, handlers, draft, options('C'));
+        expect(draft.path).toBeUndefined();
+    });
+});
+
+describe('applyJsDocHandlers', () => {
+    it('applies a matching JSDoc handler to the draft', () => {
+        const sf = compile(`
+            /**
+             * @hidden
+             */
+            class C {}
+        `);
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const handlers: ControllerJsDocHandler[] = [
+            { match: { tag: 'hidden' }, apply: (_ctx, d: ControllerDraft) => { d.hidden = true; } },
+        ];
+
+        applyJsDocHandlers(node, handlers, draft, options('C'));
+        expect(draft.hidden).toBe(true);
+    });
+
+    it('exposes the source object on the context', () => {
+        const sf = compile(`
+            /**
+             * @description short text
+             */
+            class C {}
+        `);
+        const node = findClass(sf, 'C');
+        const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
+        const seen: string[] = [];
+        const handlers: ControllerJsDocHandler[] = [
+            {
+                match: { tag: 'description' },
+                apply: (ctx) => { if (ctx.source.text) seen.push(ctx.source.text); },
+            },
+        ];
+
+        applyJsDocHandlers(node, handlers, draft, options('C'));
+        expect(seen).toEqual(['short text']);
+    });
+
+    it('passes the parameterType callback through', () => {
+        const sf = compile('class C {}');
+        const node = findClass(sf, 'C');
+        const draft = newMethodDraft({ name: 'list' });
+        const handlers: MethodHandler[] = [];
+
+        applyDecoratorHandlers(node, handlers, draft, {
+            target: 'method',
+            host: { name: 'list' },
+            resolveTypeNode: stubResolveTypeNode,
+            parameterType: () => ({ typeName: 'string' } as Type),
+        });
+        // No assertion target — covers the parameterType wiring path without runtime crash.
+        expect(draft.parameters).toEqual([]);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete decorator preset for @trapi/decorators with support for controllers, methods, parameters, and JSDoc tags
  * Extended decorator v2 metadata adapter exports for improved API accessibility

* **Tests**
  * Added comprehensive test suite for decorator orchestration functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->