### PR TITLE
feat(cli): add @trapi/cli package with  command

### DIFF
--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -10,6 +10,7 @@ trapi/
 │   ├── decorators/        # Reference decorator preset (HTTP methods, params, etc.)
 │   ├── preset-typescript-rest/    # typescript-rest adapter
 │   ├── preset-decorators-express/ # @decorators/express adapter
+│   ├── cli/               # `trapi` CLI (citty) wrapping the metadata + swagger pipeline
 │   └── docs/              # VitePress documentation site
 ├── nx.json                # NX workspace config (build/test/lint caching)
 ├── tsconfig.json          # Base TS config (noEmit, baseUrl)
@@ -22,7 +23,7 @@ trapi/
 Build order flows bottom-to-top:
 
 ```
-Layer 3 (consumers):  preset-typescript-rest, preset-decorators-express, docs
+Layer 3 (consumers):  preset-typescript-rest, preset-decorators-express, cli, docs
 Layer 2 (generation): swagger, decorators
 Layer 1 (core):       metadata
 ```
@@ -118,3 +119,20 @@ Publishes as `@trapi/decorators`. Acts both as a runtime decorator library and a
 ## Package: Presets
 
 `preset-typescript-rest` and `preset-decorators-express` map framework-specific decorator names to v2 handlers. Each preset exports a `Preset` object as the default export. `preset-decorators-express` extends `@trapi/decorators` (most decorator names overlap); `preset-typescript-rest` is standalone (its naming conventions diverge — `@Path` for routes, `@QueryParam`, `ContextRequest` family, etc.).
+
+## Package: `@trapi/cli`
+
+Thin [citty](https://github.com/unjs/citty)-based CLI that wraps `generateSwagger` + `saveSwagger`. The bin entry follows the authup pattern: an async factory `createCLIEntryPointCommand()` builds the root command, and `runMain()` dispatches subcommands.
+
+```
+packages/cli/src/
+├── bin.ts             # Bin entry (#!/usr/bin/env node + runMain)
+├── module.ts          # createCLIEntryPointCommand() — root command factory
+├── commands/
+│   ├── generate.ts    # `trapi generate` subcommand
+│   └── index.ts
+├── utils.ts           # readPackageJson() for meta
+└── index.ts           # Re-exports the factory + commands
+```
+
+Bin name: `trapi`. Depends on `@trapi/metadata` and `@trapi/swagger`. Publishes its bin via the `bin` field in `package.json` (`"trapi": "dist/bin.mjs"`).

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/decorators":"1.3.0","packages/metadata":"1.3.0","packages/swagger":"1.3.0","packages/preset-decorators-express":"0.1.8","packages/preset-typescript-rest":"1.0.8","packages/docs":"1.0.0"}
+{"packages/cli":"0.0.0","packages/decorators":"1.3.0","packages/metadata":"1.3.0","packages/swagger":"1.3.0","packages/preset-decorators-express":"0.1.8","packages/preset-typescript-rest":"1.0.8","packages/docs":"1.0.0"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Packages are libraries published to npm. The `docs` package is a private VitePre
 | `packages/decorators` | `@trapi/decorators` | Reference decorator set + default preset |
 | `packages/preset-typescript-rest` | `@trapi/preset-typescript-rest` | Decorator mapping for typescript-rest |
 | `packages/preset-decorators-express` | `@trapi/preset-decorators-express` | Decorator mapping for @decorators/express |
+| `packages/cli` | `@trapi/cli` | `trapi` CLI wrapping `generateMetadata` + `generateSwagger` + `saveSwagger` |
 | `packages/docs` | _(private)_ | VitePress documentation site |
 
 ### Linked Versioning

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ export default {
 };
 ```
 
-Presets can `extends` other presets to inherit and override handlers — `@trapi/preset-decorators-express` extends `@trapi/decorators` and only overrides the names that diverge. JSDoc tags use the same model through dedicated `controllerJsDoc` / `methodJsDoc` / `parameterJsDoc` handler arrays.
+Presets can `extend` other presets to inherit and override handlers — `@trapi/preset-decorators-express` extends `@trapi/decorators` and only overrides the names that diverge. JSDoc tags use the same model through dedicated `controllerJsDoc` / `methodJsDoc` / `parameterJsDoc` handler arrays.
 
 This means any HTTP framework built on TypeScript decorators can get metadata extraction and OpenAPI generation for free — without changing application code.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Most tools that generate OpenAPI from decorators force you to adopt their own de
 | [@trapi/decorators](./packages/decorators) | Default decorator set and mapping |
 | [@trapi/preset-typescript-rest](./packages/preset-typescript-rest) | Preset for typescript-rest |
 | [@trapi/preset-decorators-express](./packages/preset-decorators-express) | Preset for @decorators/express |
+| [@trapi/cli](./packages/cli) | `trapi` CLI — generate OpenAPI specs straight from the shell |
 
 ## Quick Start
 
@@ -53,6 +54,16 @@ const spec = await generateSwagger({
 await saveSwagger(spec, { cwd: './docs' });
 ```
 
+Or skip the script entirely and run it from the shell with [`@trapi/cli`](./packages/cli):
+
+```bash
+npx trapi generate \
+  --preset @trapi/decorators \
+  --entry-point 'src/**/*.ts' \
+  --output docs/openapi.json \
+  --version 3.1
+```
+
 ## How It Works
 
 TRAPI uses the TypeScript compiler API to statically analyze your source code. It reads decorator metadata from the AST — no `reflect-metadata`, no runtime type information.
@@ -62,16 +73,41 @@ TypeScript Source Code  -->  Metadata Extraction  -->  OpenAPI Specification
    (your decorators)        (@trapi/metadata)          (@trapi/swagger)
 ```
 
-A **preset** maps your decorator names to TRAPI's internal concepts (controller, HTTP method, parameter source, etc.):
+A **preset** is a collection of **handlers** that match decorators by name and mutate a draft (controller, method, parameter, ...). Each handler declares what it matches and how it contributes:
 
 ```typescript
-{
-    [DecoratorID.CONTROLLER]: { name: 'Controller' },
-    [DecoratorID.GET]: { name: 'Get' },
-    [DecoratorID.BODY]: { name: 'Body' },
-    // ...
-}
+import { controller, method } from '@trapi/metadata';
+
+const controllerHandler = controller({
+    match: { name: 'Controller', on: 'class' },
+    apply: (ctx, draft) => {
+        const arg = ctx.argument(0);
+        if (typeof arg?.raw === 'string') {
+            draft.path = arg.raw;
+        }
+    },
+});
+
+const getHandler = method({
+    match: { name: 'Get', on: 'method' },
+    apply: (ctx, draft) => {
+        draft.method = 'get';
+        const arg = ctx.argument(0);
+        if (typeof arg?.raw === 'string') {
+            draft.path = arg.raw;
+        }
+    },
+});
+
+export default {
+    name: 'my-preset',
+    controllers: [controllerHandler],
+    methods: [getHandler],
+    parameters: [/* ... */],
+};
 ```
+
+Presets can `extends` other presets to inherit and override handlers — `@trapi/preset-decorators-express` extends `@trapi/decorators` and only overrides the names that diverge. JSDoc tags use the same model through dedicated `controllerJsDoc` / `methodJsDoc` / `parameterJsDoc` handler arrays.
 
 This means any HTTP framework built on TypeScript decorators can get metadata extraction and OpenAPI generation for free — without changing application code.
 
@@ -82,6 +118,7 @@ The full docs live at [https://trapi.tada5hi.net](https://trapi.tada5hi.net). Hi
 - **[Quick Start](https://trapi.tada5hi.net/guide/quick-start)** — get an OpenAPI spec on disk in five minutes
 - **[Key Concepts](https://trapi.tada5hi.net/guide/concepts)** — the mental model: decorators, mappings, metadata, emitters
 - **[Framework Integration](https://trapi.tada5hi.net/guide/framework-integration)** — using TRAPI with typescript-rest, @decorators/express, or your own decorators
+- **[CLI](https://trapi.tada5hi.net/guide/cli)** — `trapi generate` from the shell, no script required
 - **[Supported TypeScript Types](https://trapi.tada5hi.net/guide/advanced-type-support)** — what the resolver understands
 - **[Custom Presets](https://trapi.tada5hi.net/guide/advanced-custom-presets)** — publish a decorator mapping others can reuse
 - **[API Reference](https://trapi.tada5hi.net/guide/metadata-api-reference)** — stable public surface for both packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -2094,6 +2094,10 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/@trapi/cli": {
+            "resolved": "packages/cli",
+            "link": true
+        },
         "node_modules/@trapi/decorators": {
             "resolved": "packages/decorators",
             "link": true
@@ -3576,6 +3580,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -3709,6 +3722,15 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
         },
         "node_modules/conventional-changelog-angular": {
             "version": "8.3.1",
@@ -9248,6 +9270,22 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "packages/cli": {
+            "name": "@trapi/cli",
+            "version": "0.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@trapi/metadata": "^1.3.0",
+                "@trapi/swagger": "^1.3.0",
+                "citty": "^0.1.6"
+            },
+            "bin": {
+                "trapi": "dist/bin.mjs"
+            },
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "packages/decorators": {

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Placzek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,7 +81,7 @@ trapi generate \
   --entry-point 'src/api/**/*.ts' \
   --preset @trapi/decorators \
   --output docs/openapi.yaml \
-  --version 3.0
+  --version 3
 ```
 
 Override the API metadata directly from the command line:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,153 @@
+# @trapi/cli ⚡
+
+[![main](https://github.com/Tada5hi/trapi/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/trapi/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/Tada5hi/trapi/branch/main/graph/badge.svg?token=ZUJ8F5TTSX)](https://codecov.io/gh/Tada5hi/trapi)
+[![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/trapi/badge.svg)](https://snyk.io/test/github/Tada5hi/trapi)
+[![npm version](https://badge.fury.io/js/@trapi%2Fcli.svg)](https://badge.fury.io/js/@trapi%2Fcli)
+
+A thin command-line wrapper around [`@trapi/metadata`](../metadata) and [`@trapi/swagger`](../swagger). It replaces the boilerplate `tsx scripts/generate-openapi.ts` script every consumer ends up writing — point it at your sources and it emits an OpenAPI / Swagger document.
+
+Built on [citty](https://github.com/unjs/citty), so `--help` is wired up automatically and arguments are validated up-front.
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Commands](#commands)
+  - [`trapi generate`](#trapi-generate)
+- [Programmatic Usage](#programmatic-usage)
+- [Structure](#structure)
+- [License](#license)
+
+## Installation
+
+```bash
+npm install --save-dev @trapi/cli
+```
+
+The CLI ships a `trapi` bin. Install it in the project that owns the controllers — `@trapi/metadata` and `@trapi/swagger` are pulled in transitively, but you'll typically also install the preset you want to use (e.g. `@trapi/decorators`).
+
+## Quick Start
+
+```bash
+npx trapi generate \
+  --preset @trapi/decorators \
+  --entry-point 'src/**/*.ts' \
+  --output docs/openapi.json \
+  --version 3.1
+```
+
+The example above:
+
+1. Loads the [`@trapi/decorators`](../decorators) preset.
+2. Scans every `.ts` file under `src/` for decorated controllers.
+3. Generates an OpenAPI **3.1** document.
+4. Writes it to `docs/openapi.json` (the `.json` extension picks the format automatically).
+
+Pass `--format yaml` or use a `.yaml`/`.yml` extension to emit YAML instead. Both `--version 3.1` and `--version v3.1` are accepted.
+
+## Commands
+
+### `trapi generate`
+
+Generate an OpenAPI / Swagger specification from decorated TypeScript sources.
+
+```bash
+trapi generate [OPTIONS] --entry-point=<glob>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--entry-point` _(required)_ | Glob pattern matching the source files to scan. | — |
+| `--preset` | Preset to load (npm package name or local path). | _none_ |
+| `--tsconfig` | Path to a `tsconfig.json` used to compile the sources. | _none_ |
+| `--output` | Output file path. The extension picks the format unless `--format` is set. | `swagger.json` |
+| `--format` | Output document format (`json` \| `yaml`). | inferred from `--output` |
+| `--version` | OpenAPI specification version (`v2` \| `v3` \| `v3.1` \| `v3.2`). The leading `v` is optional. | `v3` |
+| `--strict` | Warn on decorators that no preset handler matched (catches typos like `@Hiden`). | `false` |
+| `--cache` | Cache the generated metadata between runs. | `false` |
+| `--name` | API name written into the spec `info` object. | _package.json_ |
+| `--api-version` | API version written into the spec `info` object. | _package.json_ |
+| `--description` | API description written into the spec `info` object. | _package.json_ |
+
+Run `trapi generate --help` to see this list rendered against the installed version.
+
+#### Examples
+
+Generate a YAML 3.0 spec from controllers under `src/api/`:
+
+```bash
+trapi generate \
+  --entry-point 'src/api/**/*.ts' \
+  --preset @trapi/decorators \
+  --output docs/openapi.yaml \
+  --version 3.0
+```
+
+Override the API metadata directly from the command line:
+
+```bash
+trapi generate \
+  --entry-point 'src/**/*.ts' \
+  --output spec.json \
+  --name "Acme API" \
+  --api-version 1.4.2 \
+  --description "Internal Acme service surface."
+```
+
+Use a custom `tsconfig.json` and surface decorator typos as warnings:
+
+```bash
+trapi generate \
+  --entry-point 'src/**/*.ts' \
+  --tsconfig tsconfig.api.json \
+  --preset @trapi/decorators \
+  --strict
+```
+
+## Programmatic Usage
+
+The same building blocks the CLI uses are exported from the package, so you can embed them in custom scripts (or build sibling commands on top):
+
+```typescript
+import { runMain } from 'citty';
+import { createCLIEntryPointCommand } from '@trapi/cli';
+
+const command = await createCLIEntryPointCommand();
+await runMain(command);
+```
+
+For one-shot programmatic generation, prefer using `@trapi/swagger` directly:
+
+```typescript
+import { generateSwagger, saveSwagger } from '@trapi/swagger';
+
+const spec = await generateSwagger({
+    version: 'v3.1',
+    metadata: {
+        entryPoint: 'src/**/*.ts',
+        preset: '@trapi/decorators',
+    },
+});
+
+await saveSwagger(spec, { name: 'openapi', cwd: 'docs' });
+```
+
+## Structure
+
+```
+src/
+├── bin.ts           # #!/usr/bin/env node — calls runMain()
+├── module.ts        # createCLIEntryPointCommand() — root command factory
+├── commands/
+│   ├── generate.ts  # `trapi generate` subcommand
+│   └── index.ts
+├── utils.ts         # readPackageJson() for citty meta
+└── index.ts         # Public exports
+```
+
+## License
+
+Made with 💚
+
+Published under [MIT License](./LICENSE).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,61 @@
+{
+    "name": "@trapi/cli",
+    "version": "0.0.0",
+    "description": "CLI for generating REST-API metadata and OpenAPI / Swagger specifications.",
+    "type": "module",
+    "main": "dist/index.mjs",
+    "types": "dist/index.d.mts",
+    "bin": {
+        "trapi": "dist/bin.mjs"
+    },
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "keywords": [
+        "trapi",
+        "cli",
+        "typescript",
+        "REST-API",
+        "swagger",
+        "openapi",
+        "generation"
+    ],
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Tada5hi/trapi.git",
+        "directory": "packages/cli"
+    },
+    "bugs": {
+        "url": "https://github.com/Tada5hi/trapi/issues"
+    },
+    "homepage": "https://github.com/Tada5hi/trapi#readme",
+    "scripts": {
+        "build": "npm run build:js && npm run build:types",
+        "build:js": "tsdown",
+        "build:types": "tsc -p tsconfig.build.json"
+    },
+    "dependencies": {
+        "@trapi/metadata": "^1.3.0",
+        "@trapi/swagger": "^1.3.0",
+        "citty": "^0.1.6"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,9 @@
     "scripts": {
         "build": "npm run build:js && npm run build:types",
         "build:js": "tsdown",
-        "build:types": "tsc -p tsconfig.build.json"
+        "build:types": "tsc -p tsconfig.build.json",
+        "test": "vitest --config ./test/vitest.config.ts --run",
+        "test:coverage": "vitest --config ./test/vitest.config.ts --run --coverage"
     },
     "dependencies": {
         "@trapi/metadata": "^1.3.0",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { runMain } from 'citty';
+import { createCLIEntryPointCommand } from './module.ts';
+
+Promise.resolve()
+    .then(() => createCLIEntryPointCommand())
+    .then((command) => runMain(command))
+    .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        process.exit(1);
+    });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import process from 'node:process';
+import { defineCommand } from 'citty';
+import type { MetadataGenerateOptions } from '@trapi/metadata';
+import type { SwaggerGenerateOptions } from '@trapi/swagger';
+import {
+    DocumentFormat,
+    Version,
+    generateSwagger,
+    saveSwagger,
+} from '@trapi/swagger';
+
+const VERSION_VALUES = Object.values(Version);
+const FORMAT_VALUES = Object.values(DocumentFormat);
+
+function normalizeVersion(input: string): `${Version}` {
+    const value = input.startsWith('v') ? input : `v${input}`;
+    if (!(VERSION_VALUES as string[]).includes(value)) {
+        throw new Error(
+            `Unknown OpenAPI version "${input}". Supported: ${VERSION_VALUES.join(', ')}.`,
+        );
+    }
+    return value as `${Version}`;
+}
+
+function detectFormatFromPath(filePath: string): `${DocumentFormat}` | undefined {
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === '.yaml' || ext === '.yml') {
+        return DocumentFormat.YAML;
+    }
+    if (ext === '.json') {
+        return DocumentFormat.JSON;
+    }
+    return undefined;
+}
+
+type ResolvedOutput = {
+    cwd: string;
+    name: string;
+    format: `${DocumentFormat}`;
+};
+
+function resolveOutput(
+    output: string | undefined,
+    formatArg: string | undefined,
+): ResolvedOutput {
+    const fallback = output ?? 'swagger.json';
+    const absolute = path.isAbsolute(fallback) ?
+        fallback :
+        path.join(process.cwd(), fallback);
+
+    const format = ((): `${DocumentFormat}` => {
+        if (formatArg) {
+            if (!(FORMAT_VALUES as string[]).includes(formatArg)) {
+                throw new Error(
+                    `Unknown output format "${formatArg}". Supported: ${FORMAT_VALUES.join(', ')}.`,
+                );
+            }
+            return formatArg as `${DocumentFormat}`;
+        }
+        return detectFormatFromPath(absolute) ?? DocumentFormat.JSON;
+    })();
+
+    const ext = path.extname(absolute);
+    const baseName = path.basename(absolute, ext);
+
+    return {
+        cwd: path.dirname(absolute),
+        name: baseName,
+        format,
+    };
+}
+
+export function defineCLIGenerateCommand() {
+    return defineCommand({
+        meta: {
+            name: 'generate',
+            description: 'Generate an OpenAPI / Swagger specification from decorated TypeScript sources.',
+        },
+        args: {
+            'entry-point': {
+                type: 'string',
+                description: 'Glob pattern matching the source files to scan.',
+                valueHint: 'src/**/*.ts',
+                required: true,
+            },
+            preset: {
+                type: 'string',
+                description: 'Preset to load (npm package name or local path).',
+                valueHint: '@trapi/decorators',
+            },
+            tsconfig: {
+                type: 'string',
+                description: 'Path to a tsconfig.json file used to compile the sources.',
+            },
+            output: {
+                type: 'string',
+                description: 'Output file path. Extension picks the format unless --format is set.',
+                valueHint: 'docs/openapi.json',
+                default: 'swagger.json',
+            },
+            format: {
+                type: 'string',
+                description: 'Output document format.',
+                valueHint: FORMAT_VALUES.join('|'),
+                options: FORMAT_VALUES as string[],
+            },
+            version: {
+                type: 'string',
+                description: 'OpenAPI specification version.',
+                valueHint: VERSION_VALUES.join('|'),
+                default: Version.V3,
+            },
+            strict: {
+                type: 'boolean',
+                description: 'Warn on decorators that no preset handler matched.',
+                default: false,
+            },
+            cache: {
+                type: 'boolean',
+                description: 'Cache the generated metadata between runs (off by default).',
+                default: false,
+            },
+            name: {
+                type: 'string',
+                description: 'API name written into the spec info object.',
+            },
+            'api-version': {
+                type: 'string',
+                description: 'API version written into the spec info object.',
+            },
+            description: {
+                type: 'string',
+                description: 'API description written into the spec info object.',
+            },
+        },
+        async run({ args }) {
+            const version = normalizeVersion(String(args.version));
+            const output = resolveOutput(
+                args.output as string | undefined,
+                args.format as string | undefined,
+            );
+
+            const metadata: MetadataGenerateOptions = {
+                entryPoint: args['entry-point'] as string,
+                preset: args.preset as string | undefined,
+                tsconfig: args.tsconfig as string | undefined,
+                strict: args.strict ? true : undefined,
+                cache: args.cache ? true : undefined,
+            };
+
+            const swaggerOptions: SwaggerGenerateOptions = {
+                version,
+                metadata,
+                data: {
+                    name: args.name as string | undefined,
+                    version: args['api-version'] as string | undefined,
+                    description: args.description as string | undefined,
+                },
+            };
+
+            const spec = await generateSwagger(swaggerOptions);
+            const result = await saveSwagger(spec, {
+                cwd: output.cwd,
+                name: output.name,
+                format: output.format,
+            });
+
+            // eslint-disable-next-line no-console
+            console.log(`[trapi] wrote ${result.path}`);
+        },
+    });
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -5,78 +5,20 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import path from 'node:path';
-import process from 'node:process';
 import { defineCommand } from 'citty';
 import type { MetadataGenerateOptions } from '@trapi/metadata';
 import type { SwaggerGenerateOptions } from '@trapi/swagger';
 import {
-    DocumentFormat,
     Version,
     generateSwagger,
     saveSwagger,
 } from '@trapi/swagger';
-
-const VERSION_VALUES = Object.values(Version);
-const FORMAT_VALUES = Object.values(DocumentFormat);
-
-function normalizeVersion(input: string): `${Version}` {
-    const value = input.startsWith('v') ? input : `v${input}`;
-    if (!(VERSION_VALUES as string[]).includes(value)) {
-        throw new Error(
-            `Unknown OpenAPI version "${input}". Supported: ${VERSION_VALUES.join(', ')}.`,
-        );
-    }
-    return value as `${Version}`;
-}
-
-function detectFormatFromPath(filePath: string): `${DocumentFormat}` | undefined {
-    const ext = path.extname(filePath).toLowerCase();
-    if (ext === '.yaml' || ext === '.yml') {
-        return DocumentFormat.YAML;
-    }
-    if (ext === '.json') {
-        return DocumentFormat.JSON;
-    }
-    return undefined;
-}
-
-type ResolvedOutput = {
-    cwd: string;
-    name: string;
-    format: `${DocumentFormat}`;
-};
-
-function resolveOutput(
-    output: string | undefined,
-    formatArg: string | undefined,
-): ResolvedOutput {
-    const fallback = output ?? 'swagger.json';
-    const absolute = path.isAbsolute(fallback) ?
-        fallback :
-        path.join(process.cwd(), fallback);
-
-    const format = ((): `${DocumentFormat}` => {
-        if (formatArg) {
-            if (!(FORMAT_VALUES as string[]).includes(formatArg)) {
-                throw new Error(
-                    `Unknown output format "${formatArg}". Supported: ${FORMAT_VALUES.join(', ')}.`,
-                );
-            }
-            return formatArg as `${DocumentFormat}`;
-        }
-        return detectFormatFromPath(absolute) ?? DocumentFormat.JSON;
-    })();
-
-    const ext = path.extname(absolute);
-    const baseName = path.basename(absolute, ext);
-
-    return {
-        cwd: path.dirname(absolute),
-        name: baseName,
-        format,
-    };
-}
+import {
+    FORMAT_VALUES,
+    VERSION_VALUES,
+    normalizeVersion,
+    resolveOutput,
+} from './utils.ts';
 
 export function defineCLIGenerateCommand() {
     return defineCommand({

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './generate.ts';

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import process from 'node:process';
+import { DocumentFormat, Version } from '@trapi/swagger';
+
+export const VERSION_VALUES = Object.values(Version);
+export const FORMAT_VALUES = Object.values(DocumentFormat);
+
+export function normalizeVersion(input: string): `${Version}` {
+    const value = input.startsWith('v') ? input : `v${input}`;
+    if (!(VERSION_VALUES as string[]).includes(value)) {
+        throw new Error(
+            `Unknown OpenAPI version "${input}". Supported: ${VERSION_VALUES.join(', ')}.`,
+        );
+    }
+    return value as `${Version}`;
+}
+
+export function detectFormatFromPath(filePath: string): `${DocumentFormat}` | undefined {
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === '.yaml' || ext === '.yml') {
+        return DocumentFormat.YAML;
+    }
+    if (ext === '.json') {
+        return DocumentFormat.JSON;
+    }
+    return undefined;
+}
+
+export type ResolvedOutput = {
+    cwd: string;
+    name: string;
+    format: `${DocumentFormat}`;
+};
+
+export function resolveOutput(
+    output: string | undefined,
+    formatArg: string | undefined,
+): ResolvedOutput {
+    const fallback = output ?? 'swagger.json';
+    const absolute = path.isAbsolute(fallback) ?
+        fallback :
+        path.join(process.cwd(), fallback);
+
+    const format = ((): `${DocumentFormat}` => {
+        if (formatArg) {
+            if (!(FORMAT_VALUES as string[]).includes(formatArg)) {
+                throw new Error(
+                    `Unknown output format "${formatArg}". Supported: ${FORMAT_VALUES.join(', ')}.`,
+                );
+            }
+            return formatArg as `${DocumentFormat}`;
+        }
+        return detectFormatFromPath(absolute) ?? DocumentFormat.JSON;
+    })();
+
+    const ext = path.extname(absolute);
+    const baseName = path.basename(absolute, ext);
+
+    return {
+        cwd: path.dirname(absolute),
+        name: baseName,
+        format,
+    };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './commands';
+export * from './module.ts';

--- a/packages/cli/src/module.ts
+++ b/packages/cli/src/module.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { defineCommand } from 'citty';
+import { readPackageJson } from './utils.ts';
+import { defineCLIGenerateCommand } from './commands';
+
+export async function createCLIEntryPointCommand() {
+    const pkg = await readPackageJson();
+
+    return defineCommand({
+        meta: {
+            name: pkg.name ?? '@trapi/cli',
+            version: pkg.version ?? '0.0.0',
+            description: pkg.description ?? 'CLI for the trapi metadata + swagger pipeline.',
+        },
+        subCommands: { generate: defineCLIGenerateCommand() },
+    });
+}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type PackageJson = {
+    name?: string;
+    version?: string;
+    description?: string;
+};
+
+export async function readPackageJson(): Promise<PackageJson> {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+        join(here, '..', 'package.json'),
+        join(here, '..', '..', 'package.json'),
+    ];
+
+    for (const candidate of candidates) {
+        try {
+            const raw = await readFile(candidate, { encoding: 'utf-8' });
+            return JSON.parse(raw) as PackageJson;
+        } catch {
+            // continue
+        }
+    }
+
+    return {};
+}

--- a/packages/cli/test/unit/commands/utils.spec.ts
+++ b/packages/cli/test/unit/commands/utils.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import process from 'node:process';
+import { describe, expect, it } from 'vitest';
+import {
+    detectFormatFromPath,
+    normalizeVersion,
+    resolveOutput,
+} from '../../../src/commands/utils.ts';
+
+describe('normalizeVersion', () => {
+    it('accepts canonical values verbatim', () => {
+        expect(normalizeVersion('v2')).toBe('v2');
+        expect(normalizeVersion('v3')).toBe('v3');
+        expect(normalizeVersion('v3.1')).toBe('v3.1');
+        expect(normalizeVersion('v3.2')).toBe('v3.2');
+    });
+
+    it('prefixes a leading "v" when omitted', () => {
+        expect(normalizeVersion('2')).toBe('v2');
+        expect(normalizeVersion('3')).toBe('v3');
+        expect(normalizeVersion('3.1')).toBe('v3.1');
+        expect(normalizeVersion('3.2')).toBe('v3.2');
+    });
+
+    it('throws with the supported list when the value is unknown', () => {
+        expect(() => normalizeVersion('bogus')).toThrowError(
+            /Unknown OpenAPI version "bogus"\. Supported: v2, v3, v3\.1, v3\.2\./,
+        );
+    });
+
+    it('throws for almost-valid values that miss the supported set', () => {
+        expect(() => normalizeVersion('v3.0')).toThrowError(/Unknown OpenAPI version/);
+        expect(() => normalizeVersion('4')).toThrowError(/Unknown OpenAPI version/);
+    });
+});
+
+describe('detectFormatFromPath', () => {
+    it('returns yaml for .yaml and .yml extensions', () => {
+        expect(detectFormatFromPath('spec.yaml')).toBe('yaml');
+        expect(detectFormatFromPath('spec.yml')).toBe('yaml');
+        expect(detectFormatFromPath('/abs/path/openapi.YAML')).toBe('yaml');
+    });
+
+    it('returns json for .json extension', () => {
+        expect(detectFormatFromPath('spec.json')).toBe('json');
+        expect(detectFormatFromPath('docs/api.JSON')).toBe('json');
+    });
+
+    it('returns undefined for unrecognised or missing extensions', () => {
+        expect(detectFormatFromPath('spec')).toBeUndefined();
+        expect(detectFormatFromPath('spec.txt')).toBeUndefined();
+        expect(detectFormatFromPath('spec.toml')).toBeUndefined();
+    });
+});
+
+describe('resolveOutput', () => {
+    it('falls back to swagger.json under cwd when output is undefined', () => {
+        const result = resolveOutput(undefined, undefined);
+        expect(result).toEqual({
+            cwd: process.cwd(),
+            name: 'swagger',
+            format: 'json',
+        });
+    });
+
+    it('infers json from a relative .json output and resolves cwd against process.cwd()', () => {
+        const result = resolveOutput('docs/openapi.json', undefined);
+        expect(result).toEqual({
+            cwd: path.join(process.cwd(), 'docs'),
+            name: 'openapi',
+            format: 'json',
+        });
+    });
+
+    it('infers yaml from a .yaml extension', () => {
+        const result = resolveOutput('spec.yaml', undefined);
+        expect(result).toEqual({
+            cwd: process.cwd(),
+            name: 'spec',
+            format: 'yaml',
+        });
+    });
+
+    it('keeps an absolute path verbatim', () => {
+        const abs = path.resolve('/tmp', 'cli-test', 'openapi.yaml');
+        const result = resolveOutput(abs, undefined);
+        expect(result).toEqual({
+            cwd: path.dirname(abs),
+            name: 'openapi',
+            format: 'yaml',
+        });
+    });
+
+    it('lets --format override the extension-derived format', () => {
+        const result = resolveOutput('spec.json', 'yaml');
+        expect(result.format).toBe('yaml');
+        expect(result.name).toBe('spec');
+    });
+
+    it('defaults to json when the extension is unrecognised and --format is unset', () => {
+        const result = resolveOutput('spec.txt', undefined);
+        expect(result).toEqual({
+            cwd: process.cwd(),
+            name: 'spec',
+            format: 'json',
+        });
+    });
+
+    it('throws on an unsupported --format value', () => {
+        expect(() => resolveOutput('spec.json', 'bogus')).toThrowError(
+            /Unknown output format "bogus"\. Supported: yaml, json\./,
+        );
+    });
+});

--- a/packages/cli/test/vitest.config.ts
+++ b/packages/cli/test/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            exclude: [
+                'src/**/*.d.ts',
+                'src/bin.ts',
+                'src/utils.ts',
+                'src/commands/generate.ts',
+                'src/module.ts',
+                'src/index.ts',
+                'src/commands/index.ts',
+            ],
+        },
+    },
+});

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.build.json",
     "include": [
-        "src/**/*.ts"
+        "src/**/*.ts",
+        "test/**/*.ts"
     ]
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "paths": {
+            "@trapi/metadata": ["./packages/metadata/src"],
+            "@trapi/swagger": ["./packages/swagger/src"]
+        }
+    }
+}

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: ['src/index.ts', 'src/bin.ts'],
+    format: 'esm',
+    dts: true,
+    sourcemap: true,
+});

--- a/packages/docs/src/.vitepress/config.mjs
+++ b/packages/docs/src/.vitepress/config.mjs
@@ -64,6 +64,13 @@ export default defineConfig({
                     ]
                 },
                 {
+                    text: 'CLI',
+                    collapsible: false,
+                    items: [
+                        { text: '@trapi/cli', link: '/guide/cli' },
+                    ]
+                },
+                {
                     text: 'Advanced',
                     collapsible: false,
                     items: [

--- a/packages/docs/src/guide/cli.md
+++ b/packages/docs/src/guide/cli.md
@@ -63,7 +63,7 @@ trapi generate \
   --entry-point 'src/api/**/*.ts' \
   --preset @trapi/decorators \
   --output docs/openapi.yaml \
-  --version 3.0
+  --version 3
 ```
 
 The `.yaml` suffix selects the YAML emitter; `--format` is unnecessary here.

--- a/packages/docs/src/guide/cli.md
+++ b/packages/docs/src/guide/cli.md
@@ -1,0 +1,114 @@
+# CLI
+
+[`@trapi/cli`](https://www.npmjs.com/package/@trapi/cli) ships a `trapi` bin that wraps `generateMetadata` + `generateSwagger` + `saveSwagger` behind a single command. Use it when you want a generated spec on disk without writing your own `tsx scripts/generate-openapi.ts`.
+
+The CLI is built on [citty](https://github.com/unjs/citty) — `--help` is wired up automatically and arguments are validated up-front.
+
+## Installation
+
+```bash
+npm install --save-dev @trapi/cli
+```
+
+`@trapi/metadata` and `@trapi/swagger` are pulled in transitively. You'll typically also install the preset you want to use (e.g. `@trapi/decorators`).
+
+```bash
+npm install --save-dev @trapi/decorators
+```
+
+## Quick Start
+
+```bash
+npx trapi generate \
+  --preset @trapi/decorators \
+  --entry-point 'src/**/*.ts' \
+  --output docs/openapi.json \
+  --version 3.1
+```
+
+This loads the [`@trapi/decorators`](/guide/metadata-decorators) preset, scans every `.ts` file under `src/` for decorated controllers, and writes an OpenAPI 3.1 document to `docs/openapi.json`. Both `--version 3.1` and `--version v3.1` are accepted; the `.json` suffix on `--output` picks the format automatically.
+
+## Commands
+
+### `trapi generate`
+
+Generate an OpenAPI / Swagger specification from decorated TypeScript sources.
+
+```bash
+trapi generate [OPTIONS] --entry-point=<glob>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--entry-point` _(required)_ | Glob pattern matching the source files to scan. | — |
+| `--preset` | Preset to load (npm package name or local path). | _none_ |
+| `--tsconfig` | Path to a `tsconfig.json` used to compile the sources. | _none_ |
+| `--output` | Output file path. The extension picks the format unless `--format` is set. | `swagger.json` |
+| `--format` | Output document format (`json` \| `yaml`). | inferred from `--output` |
+| `--version` | OpenAPI specification version (`v2` \| `v3` \| `v3.1` \| `v3.2`). The leading `v` is optional. | `v3` |
+| `--strict` | Warn on decorators that no preset handler matched (catches typos like `@Hiden`). | `false` |
+| `--cache` | Cache the generated metadata between runs. | `false` |
+| `--name` | API name written into the spec `info` object. | _package.json_ |
+| `--api-version` | API version written into the spec `info` object. | _package.json_ |
+| `--description` | API description written into the spec `info` object. | _package.json_ |
+
+Run `trapi generate --help` to render the same list against the installed version.
+
+## Examples
+
+### YAML output for OpenAPI 3.0
+
+```bash
+trapi generate \
+  --entry-point 'src/api/**/*.ts' \
+  --preset @trapi/decorators \
+  --output docs/openapi.yaml \
+  --version 3.0
+```
+
+The `.yaml` suffix selects the YAML emitter; `--format` is unnecessary here.
+
+### Override the spec `info` object
+
+```bash
+trapi generate \
+  --entry-point 'src/**/*.ts' \
+  --output spec.json \
+  --name "Acme API" \
+  --api-version 1.4.2 \
+  --description "Internal Acme service surface."
+```
+
+When the `info` flags are omitted, values fall back to the nearest `package.json` — same behaviour as `generateSwagger` called programmatically.
+
+### Custom `tsconfig.json` and strict-mode reporting
+
+```bash
+trapi generate \
+  --entry-point 'src/**/*.ts' \
+  --tsconfig tsconfig.api.json \
+  --preset @trapi/decorators \
+  --strict
+```
+
+`--strict` is a boolean today (warn mode). The full `'throw'` variant is reachable via the programmatic API — see [Metadata Configuration](/guide/metadata-configuration).
+
+## Programmatic Usage
+
+The same factory the bin uses is exported from the package, in case you want to embed it or build sibling commands on top:
+
+```typescript
+import { runMain } from 'citty';
+import { createCLIEntryPointCommand } from '@trapi/cli';
+
+const command = await createCLIEntryPointCommand();
+await runMain(command);
+```
+
+For one-shot programmatic generation, prefer using `@trapi/swagger` directly — see [Generating a Spec](/guide/swagger-generation).
+
+## Limitations
+
+- **Single entry-point glob.** `--entry-point` accepts one glob string today; the metadata layer also supports arrays and `EntryPointOptions[]` programmatically. Multiple entry points are a planned follow-up.
+- **No `--watch` yet.** Re-run the command on file changes through your existing watcher of choice (e.g. `nodemon`, `chokidar-cli`) for now.
+- **No `--check` mode.** Drift detection in CI (compare generated spec against committed file) is on the roadmap.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "packages": {
+        "packages/cli": {"component": "cli" },
         "packages/decorators": {"component": "decorators" },
         "packages/docs": {"component": "docs" },
         "packages/metadata": {"component": "metadata" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `@trapi/cli` package with a command-line interface for generating OpenAPI/Swagger specifications from decorated TypeScript sources using `trapi generate` command with support for entry points, presets, output formats, and spec metadata configuration.

* **Documentation**
  * Added comprehensive CLI guide with installation, usage examples, and configuration flag documentation.
  * Updated README with CLI quick start workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->