### PR TITLE
feat(metadata,swagger,decorators): support multiple mount paths per c…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -36,6 +36,8 @@ The metadata generator modules in `@trapi/metadata`:
 
 Each generator builds a draft via `applyDecoratorHandlers` + `applyJsDocHandlers` from the v2 orchestrator, then finalises the draft into `Controller`/`Method`/`Parameter`. The controller generator walks `heritageClauses` to include decorated methods from base classes, using the type checker to resolve import aliases. Inherited methods from generic base classes with unresolvable type parameters are skipped gracefully.
 
+**Multi-mount controllers.** `Controller.paths: string[]` (always non-empty) holds every URL prefix the controller is mounted at — `@Controller(['/roles', '/realms/:id/roles'])` produces two entries, `@Controller('/roles')` produces one. Method paths stay scalar; the swagger emitter expands the cross product (see "Swagger Generator" below). Path-parameter validation in the parameter generator accepts a name if it appears in **any** `(controllerPath × methodPath)` combination, so `@Path('id')` is valid as long as `:id` shows up in at least one mount.
+
 ## Type Resolution
 
 The resolver handles TypeScript type constructs:
@@ -58,8 +60,14 @@ Presets declare **handlers** that match against a decorator name and mutate a **
 const controllerHandler = controller({
     match: { name: 'Controller', on: 'class' },
     apply: (ctx, draft) => {
-        const path = readString(ctx.argument(0));
-        draft.path = path ?? '';
+        const arg = ctx.argument(0);
+        if (arg?.kind === 'literal' && typeof arg.raw === 'string') {
+            draft.paths = [arg.raw];
+        } else if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+            draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+        } else {
+            draft.paths = [''];
+        }
     },
 });
 ```
@@ -112,6 +120,8 @@ The abstract generator handles shared logic: schema building, reference resoluti
 - `getSchemaForUnionType()` — `x-anyOf`-style workaround (V2) vs `anyOf` (V3)
 
 Version-specific generators also handle structural format differences (e.g., `requestBody` in V3 vs `in: body` parameters in V2). `V3Generator` covers 3.0, 3.1, and 3.2 via a single class; its `isV31OrLater()` check toggles behaviour like `$ref`-sibling stripping (OpenAPI 3.1 relaxed that restriction, so v3.1/v3.2 keep siblings while v3.0 strips them).
+
+**Path emission for multi-mount controllers.** Both emitters iterate `controller.paths × method.path` and emit one OpenAPI path entry per combination. `operationId` collisions across mounts are disambiguated with a numeric suffix (`list`, `list_2`, …) — V2 and V3 share a `uniqueOperationId(base, used)` helper for this. Path-bound parameters declared on the method are filtered per emitted URL: a parameter only appears on operations whose URL template actually contains `{name}` (so `:id` doesn't pollute the `/roles` operation when only `/realms/{realmId}/roles` declared it). Both V2 and V3 honour an explicit `method.operationId` override (preserved via `method.operationId || output.operationId` before disambiguation).
 
 ## Metadata Fidelity Principle
 

--- a/examples/custom-preset/src/preset.ts
+++ b/examples/custom-preset/src/preset.ts
@@ -19,9 +19,13 @@ const routeController = controller({
     match: { name: 'Route', on: 'class' },
     apply: (ctx, draft) => {
         const arg = ctx.argument(0);
-        draft.path = arg && arg.kind === 'literal' && typeof arg.raw === 'string' ?
-            arg.raw :
-            '';
+        if (arg && arg.kind === 'literal' && typeof arg.raw === 'string') {
+            draft.paths = [arg.raw];
+        } else if (arg && arg.kind === 'array' && Array.isArray(arg.raw)) {
+            draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+        } else {
+            draft.paths = [''];
+        }
     },
 });
 

--- a/examples/custom-preset/test/preset.spec.ts
+++ b/examples/custom-preset/test/preset.spec.ts
@@ -18,7 +18,7 @@ describe('@trapi/example-custom-preset', () => {
         const [controller] = metadata.controllers;
         expect(controller.name).toBe('UsersController');
         // normalizePath strips the leading slash
-        expect(controller.path).toBe('users');
+        expect(controller.paths).toEqual(['users']);
         expect(controller.tags).toEqual(['users']);
 
         const verbs = controller.methods.map((m) => m.method).sort();

--- a/packages/decorators/src/decorators/controller/module.ts
+++ b/packages/decorators/src/decorators/controller/module.ts
@@ -5,6 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export function Controller(path?: string) {
+export function Controller(path?: string | string[]) {
     return (...args) => { };
 }

--- a/packages/decorators/src/decorators/mount/module.ts
+++ b/packages/decorators/src/decorators/mount/module.ts
@@ -5,6 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export function Mount(path: string) {
+export function Mount(path: string | string[]) {
     return (...args) => { };
 }

--- a/packages/decorators/src/handlers/controller.ts
+++ b/packages/decorators/src/handlers/controller.ts
@@ -14,24 +14,24 @@ import {
     appendSecurityToDraft,
     appendTags,
     applyDescriptionToDraft,
-    readString,
+    readStringOrStringArray,
     setHidden,
 } from './shared';
 
 const controllerControllerHandler = controller({
     match: { name: 'Controller', on: 'class' },
     apply: (ctx, draft) => {
-        const path = readString(ctx.argument(0));
-        draft.path = path ?? '';
+        const paths = readStringOrStringArray(ctx.argument(0));
+        draft.paths = paths ?? [''];
     },
 });
 
 const controllerMountHandler = controller({
     match: { name: 'Mount', on: 'class' },
     apply: (ctx, draft) => {
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
+        const paths = readStringOrStringArray(ctx.argument(0));
+        if (paths !== undefined) {
+            draft.paths = paths;
         }
     },
 });

--- a/packages/decorators/src/handlers/shared.ts
+++ b/packages/decorators/src/handlers/shared.ts
@@ -27,6 +27,28 @@ export function readNumber(arg: DecoratorArgument | undefined): number | undefin
     return undefined;
 }
 
+/**
+ * Read a positional argument that may be either a single string or an array
+ * of strings. Returns `undefined` when the argument is missing or otherwise
+ * unresolvable; returns an empty array when the argument is an empty array.
+ */
+export function readStringOrStringArray(
+    arg: DecoratorArgument | undefined,
+): string[] | undefined {
+    const single = readString(arg);
+    if (single !== undefined) {
+        return [single];
+    }
+    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+        const out: string[] = [];
+        for (const item of arg.raw) {
+            if (typeof item === 'string') out.push(item);
+        }
+        return out;
+    }
+    return undefined;
+}
+
 export const setHidden = (_ctx: HandlerContext, draft: { hidden: boolean }) => {
     draft.hidden = true;
 };

--- a/packages/decorators/test/data/controllers/multi-mount.ts
+++ b/packages/decorators/test/data/controllers/multi-mount.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Controller,
+    Get,
+    Mount,
+    Path,
+} from '../../../src';
+
+@Controller(['/roles', '/realms/:realmId/roles'])
+export class RolesController {
+    @Get()
+    public list(): string[] {
+        return [];
+    }
+
+    @Get('/:id')
+    public detail(@Path('id') id: string): string {
+        return id;
+    }
+}

--- a/packages/docs/src/guide/advanced-custom-presets.md
+++ b/packages/docs/src/guide/advanced-custom-presets.md
@@ -44,9 +44,13 @@ const routeControllerHandler = controller({
     match: { name: 'Route', on: 'class' },
     apply: (ctx, draft) => {
         const arg = ctx.argument(0);
-        draft.path = arg && arg.kind === 'literal' && typeof arg.raw === 'string'
-            ? arg.raw
-            : '';
+        if (arg?.kind === 'literal' && typeof arg.raw === 'string') {
+            draft.paths = [arg.raw];
+        } else if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+            draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+        } else {
+            draft.paths = [''];
+        }
     },
 });
 
@@ -218,7 +222,7 @@ const metadata = await generateMetadata({
 });
 
 expect(metadata.controllers).toHaveLength(1);
-expect(metadata.controllers[0].path).toBe('/users');
+expect(metadata.controllers[0].paths).toEqual(['/users']);
 ```
 
 For lower-level unit testing, you can call `validatePreset(preset)` to verify the shape, and `loadRegistry(preset, { resolver })` to materialise a `Registry` directly without going through `generateMetadata`.

--- a/packages/docs/src/guide/framework-integration.md
+++ b/packages/docs/src/guide/framework-integration.md
@@ -68,9 +68,13 @@ const preset: Preset = {
             match: { name: 'Route', on: 'class' },
             apply: (ctx, draft) => {
                 const arg = ctx.argument(0);
-                draft.path = arg && arg.kind === 'literal' && typeof arg.raw === 'string'
-                    ? arg.raw
-                    : '';
+                if (arg?.kind === 'literal' && typeof arg.raw === 'string') {
+                    draft.paths = [arg.raw];
+                } else if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+                    draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+                } else {
+                    draft.paths = [''];
+                }
             },
         }),
     ],
@@ -131,7 +135,7 @@ const preset: Preset = {
             match: { name: 'Route', on: 'class' },
             apply: (ctx, draft) => {
                 const arg = ctx.argument(0);
-                draft.path = arg?.kind === 'literal' && typeof arg.raw === 'string' ? arg.raw : '';
+                draft.paths = arg?.kind === 'literal' && typeof arg.raw === 'string' ? [arg.raw] : [''];
             },
         }),
     ],

--- a/packages/docs/src/guide/metadata-decorators.md
+++ b/packages/docs/src/guide/metadata-decorators.md
@@ -28,9 +28,13 @@ const controllerControllerHandler = controller({
     match: { name: 'Controller', on: 'class' },
     apply: (ctx, draft) => {
         const arg = ctx.argument(0);
-        draft.path = arg && arg.kind === 'literal' && typeof arg.raw === 'string'
-            ? arg.raw
-            : '';
+        if (arg?.kind === 'literal' && typeof arg.raw === 'string') {
+            draft.paths = [arg.raw];
+        } else if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+            draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+        } else {
+            draft.paths = [''];
+        }
     },
 });
 

--- a/packages/docs/src/guide/metadata-decorators.md
+++ b/packages/docs/src/guide/metadata-decorators.md
@@ -101,6 +101,39 @@ controller({ match: { name: 'Hidden', on: 'class' }, apply: flag('hidden'), mark
 - `append(key).positional(i)` / `.positionalAll()` push values onto an array on the draft. Array arguments are flattened.
 - `flag(key, value = true)` unconditionally sets a flag. The second argument is optional — pass it for shorthand non-boolean assignments (e.g. `flag('verb', 'get')` for a verb-only HTTP method handler that doesn't read a path argument).
 
+## Multi-Mount Controllers
+
+`@Controller` and `@Mount` accept either a single path or an array of paths, letting one controller serve the same set of endpoints under multiple URL prefixes:
+
+```typescript
+import { Controller, Get, Path } from '@trapi/decorators';
+
+@Controller(['/roles', '/realms/:realmId/roles'])
+export class RolesController {
+    @Get()
+    list(): Role[] { /* ... */ }
+
+    @Get('/:id')
+    detail(@Path('id') id: string): Role { /* ... */ }
+}
+```
+
+The metadata exposes every mount as `Controller.paths: string[]` (always non-empty). The swagger emitter expands the cross product:
+
+```text
+GET  /roles
+GET  /roles/{id}
+GET  /realms/{realmId}/roles
+GET  /realms/{realmId}/roles/{id}
+```
+
+A few details worth knowing:
+
+- **OperationId disambiguation** — OpenAPI requires `operationId` to be unique. When the same method is emitted at multiple paths, the first keeps its base id and subsequent emissions get a numeric suffix (`list`, `list_2`, …). Set `operationId` explicitly via your preset's metadata if you want stable, predictable identifiers.
+- **Per-path parameter filtering** — path parameters declared on the method appear only on operations whose URL template actually contains them. `@Path('realmId')` only shows up under `/realms/{realmId}/roles*`, not under `/roles*`.
+- **Validation across mounts** — `@Path('name')` is valid as long as `:name` (or `{name}`) appears in **at least one** `(controllerPath × methodPath)` combination.
+- **Method paths stay scalar** — only controller-level paths support multiple values; method paths (`@Get('/:id')`) take a single string.
+
 ## Presets
 
 A **`Preset`** is a `name`, optional `extends`, and arrays of handlers per kind:

--- a/packages/docs/src/guide/migration-2.0.md
+++ b/packages/docs/src/guide/migration-2.0.md
@@ -48,9 +48,13 @@ const preset: Preset = {
             match: { name: 'Route', on: 'class' },
             apply: (ctx, draft) => {
                 const arg = ctx.argument(0);
-                draft.path = arg && arg.kind === 'literal' && typeof arg.raw === 'string'
-                    ? arg.raw
-                    : '';
+                if (arg?.kind === 'literal' && typeof arg.raw === 'string') {
+                    draft.paths = [arg.raw];
+                } else if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+                    draft.paths = arg.raw.filter((v): v is string => typeof v === 'string');
+                } else {
+                    draft.paths = [''];
+                }
             },
         }),
     ],
@@ -87,7 +91,7 @@ const preset: Preset = {
     controllers: [
         controller({
             match: { name: 'Route', on: 'class' },
-            apply: (_ctx, draft) => { draft.path = ''; },
+            apply: (_ctx, draft) => { draft.paths = ['']; },
         }),
     ],
 };

--- a/packages/metadata/src/adapters/cache/constants.ts
+++ b/packages/metadata/src/adapters/cache/constants.ts
@@ -11,7 +11,7 @@
  * or the cache wrapper itself). Old cache files with a different
  * version are rejected on read.
  */
-export const CACHE_SCHEMA_VERSION = '2';
+export const CACHE_SCHEMA_VERSION = '3';
 
 export const CACHE_FILE_PREFIX = '.trapi-metadata-';
 export const CACHE_FILE_SUFFIX = '.json';

--- a/packages/metadata/src/adapters/decorator/types.ts
+++ b/packages/metadata/src/adapters/decorator/types.ts
@@ -77,7 +77,7 @@ export type JsDocSource = {
 export type ControllerDraft = {
     name: string;
     location: string;
-    path?: string;
+    paths?: string[];
     hidden: boolean;
     consumes: string[];
     produces: string[];

--- a/packages/metadata/src/app/generator/controller/module.ts
+++ b/packages/metadata/src/app/generator/controller/module.ts
@@ -77,13 +77,17 @@ export class ControllerGenerator implements IControllerGenerator {
         applyJsDocHandlers(this.node, this.current.registry.controllerJsDoc, draft, options);
 
         // A class is a controller iff a controller-target handler claimed it
-        // (convention: the Controller handler sets `draft.path` to '' or a value).
-        if (draft.path === undefined) {
+        // (convention: the Controller handler sets `draft.paths` to a non-undefined value).
+        if (draft.paths === undefined) {
             return null;
         }
 
-        const path = normalizePath(draft.path);
-        const methods = this.buildMethods(path);
+        // Normalize and dedupe — a user passing `@Controller(['/roles', '/roles'])`
+        // (or paths that collide after normalization) shouldn't produce duplicate
+        // OpenAPI path keys downstream.
+        const normalized = (draft.paths.length === 0 ? [''] : draft.paths).map(normalizePath);
+        const paths = [...new Set(normalized)];
+        const methods = this.buildMethods(paths);
 
         return {
             consumes: draft.consumes,
@@ -91,7 +95,7 @@ export class ControllerGenerator implements IControllerGenerator {
             hidden: draft.hidden,
             location: draft.location,
             name: draft.name,
-            path,
+            paths,
             produces: draft.produces,
             responses: draft.responses,
             security: draft.security,
@@ -112,7 +116,7 @@ export class ControllerGenerator implements IControllerGenerator {
         };
     }
 
-    protected buildMethods(controllerPath: string): Method[] {
+    protected buildMethods(controllerPaths: string[]): Method[] {
         const set = new Set<string>();
         const output: Method[] = [];
 
@@ -128,7 +132,7 @@ export class ControllerGenerator implements IControllerGenerator {
                 continue;
             }
 
-            const method = generator.generate(controllerPath);
+            const method = generator.generate(controllerPaths);
             if (!method) {
                 continue;
             }
@@ -146,7 +150,7 @@ export class ControllerGenerator implements IControllerGenerator {
             }
 
             try {
-                const method = generator.generate(controllerPath);
+                const method = generator.generate(controllerPaths);
                 if (!method) {
                     continue;
                 }

--- a/packages/metadata/src/app/generator/method/module.ts
+++ b/packages/metadata/src/app/generator/method/module.ts
@@ -52,7 +52,7 @@ export class MethodGenerator {
         return identifier.text;
     }
 
-    public generate(controllerPath: string): Method | null {
+    public generate(controllerPaths: string[]): Method | null {
         const name = this.getMethodName();
         const draft = newMethodDraft({ name });
 
@@ -79,7 +79,7 @@ export class MethodGenerator {
         const responses = mergeDefaultResponse(draft.responses, defaultResponse);
 
         // Walk parameters.
-        const parameters = this.buildParameters(controllerPath, draft.path, draft.verb);
+        const parameters = this.buildParameters(controllerPaths, draft.path, draft.verb);
 
         // Description from leading JSDoc comment (no v2 handler covers this since it
         // isn't a tagged value).
@@ -130,13 +130,17 @@ export class MethodGenerator {
     }
 
     private buildParameters(
-        controllerPath: string,
+        controllerPaths: string[],
         methodPath: string,
         verb: string,
     ): Parameter[] {
         const controllerId = (this.node.parent as ClassDeclaration).name as Identifier;
         const methodId = this.node.name as Identifier;
-        const fullPath = path.posix.join('/', controllerPath, methodPath);
+        // Build the union of every (controllerPath × methodPath) combination so
+        // path-parameter validation accepts a parameter that's present in any
+        // mount (a controller can mount at /roles AND /realms/:id/roles).
+        const fullPaths = (controllerPaths.length === 0 ? [''] : controllerPaths)
+            .map((cp) => path.posix.join('/', cp, methodPath));
 
         const output: Parameter[] = [];
         let bodyParameterCount = 0;
@@ -147,7 +151,7 @@ export class MethodGenerator {
                 const generator = new ParameterGenerator(
                     this.node.parameters[i],
                     verb,
-                    fullPath,
+                    fullPaths,
                     this.current,
                 );
 

--- a/packages/metadata/src/app/generator/parameter/module.ts
+++ b/packages/metadata/src/app/generator/parameter/module.ts
@@ -281,8 +281,15 @@ export class ParameterGenerator implements IParameterGenerator {
     }
 
     private pathContainsParam(name: string): boolean {
+        // Match `{name}` literally — curly braces are their own boundaries.
+        // For `:name`, require a word boundary after the name so `:id` doesn't
+        // match `:id2` (substring), but it still matches when path-to-regexp
+        // modifiers/constraints follow the name (`:id?`, `:id*`, `:id(\\d+)`).
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const colonPattern = new RegExp(`:${escaped}\\b`);
+        const bracePattern = `{${name}}`;
         for (const p of this.paths) {
-            if (p.includes(`{${name}}`) || p.includes(`:${name}`)) {
+            if (p.includes(bracePattern) || colonPattern.test(p)) {
                 return true;
             }
         }

--- a/packages/metadata/src/app/generator/parameter/module.ts
+++ b/packages/metadata/src/app/generator/parameter/module.ts
@@ -67,19 +67,19 @@ export class ParameterGenerator implements IParameterGenerator {
 
     private readonly method: string;
 
-    private readonly path: string;
+    private readonly paths: string[];
 
     private readonly current: IGeneratorContext;
 
     constructor(
         parameter: ts.ParameterDeclaration,
         method: string,
-        path: string,
+        paths: string[],
         current: IGeneratorContext,
     ) {
         this.parameter = parameter;
         this.method = method;
-        this.path = path;
+        this.paths = paths.length === 0 ? [''] : paths;
         this.current = current;
     }
 
@@ -280,16 +280,22 @@ export class ParameterGenerator implements IParameterGenerator {
         return output;
     }
 
+    private pathContainsParam(name: string): boolean {
+        for (const p of this.paths) {
+            if (p.includes(`{${name}}`) || p.includes(`:${name}`)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private validatePathDecomposition(decomposed: Parameter[]): void {
         for (const element of decomposed) {
-            if (
-                !this.path.includes(`{${element.name}}`) &&
-                !this.path.includes(`:${element.name}`)
-            ) {
+            if (!this.pathContainsParam(element.name)) {
                 throw ParameterError.invalidPathMatch({
                     decoratorName: 'Path',
                     propertyName: element.name,
-                    path: this.path,
+                    path: this.paths.join(' | '),
                     node: this.parameter,
                 });
             }
@@ -298,14 +304,11 @@ export class ParameterGenerator implements IParameterGenerator {
 
     private validatePathName(name: string, parameterName: string): void {
         const candidate = name || parameterName;
-        if (
-            !this.path.includes(`{${candidate}}`) &&
-            !this.path.includes(`:${candidate}`)
-        ) {
+        if (!this.pathContainsParam(candidate)) {
             throw ParameterError.invalidPathMatch({
                 decoratorName: 'Path',
                 propertyName: candidate,
-                path: this.path,
+                path: this.paths.join(' | '),
                 node: this.parameter,
             });
         }

--- a/packages/metadata/src/core/controller/types.ts
+++ b/packages/metadata/src/core/controller/types.ts
@@ -38,9 +38,13 @@ export type Controller = {
     methods: Method[];
     name: string;
     /**
-     * The relative URL Path, i.e /users
+     * Relative URL paths the controller mounts at, e.g. ['/users'] or
+     * ['/roles', '/realms/:id/roles'] for multi-mounting.
+     *
+     * Always non-empty; a controller declared with no path argument has
+     * `paths: ['']`.
      */
-    path: string;
+    paths: string[];
 
     /**
      * Possible Content-Types to receive

--- a/packages/metadata/test/unit/cache.spec.ts
+++ b/packages/metadata/test/unit/cache.spec.ts
@@ -69,7 +69,7 @@ describe('src/cache', () => {
                     location: '/test.ts',
                     methods: [],
                     name: 'TestController',
-                    path: 'test',
+                    paths: ['test'],
                     produces: [],
                     responses: [],
                     security: [],
@@ -111,7 +111,7 @@ describe('src/cache', () => {
                     location: '/a.ts',
                     methods: [],
                     name: 'A',
-                    path: 'a',
+                    paths: ['a'],
                     produces: [],
                     responses: [],
                     security: [],
@@ -612,14 +612,14 @@ describe('src/cache', () => {
                 ...emptyRegistry,
                 controllers: [{
                     match: { name: 'Controller', on: 'class' },
-                    apply: (_ctx: any, draft: any) => { draft.path = 'a'; },
+                    apply: (_ctx: any, draft: any) => { draft.paths = ['a']; },
                 } as any],
             });
             const b = hashRegistry({
                 ...emptyRegistry,
                 controllers: [{
                     match: { name: 'Controller', on: 'class' },
-                    apply: (_ctx: any, draft: any) => { draft.path = 'b'; },
+                    apply: (_ctx: any, draft: any) => { draft.paths = ['b']; },
                 } as any],
             });
             expect(a).not.toEqual(b);

--- a/packages/metadata/test/unit/decorator/helpers.spec.ts
+++ b/packages/metadata/test/unit/decorator/helpers.spec.ts
@@ -33,30 +33,30 @@ function makeContext(args: DecoratorArgument[], typeArgs: DecoratorTypeArgument[
 describe('into', () => {
     it('positional(i) writes literal arg into draft key', () => {
         const draft = newControllerDraft({ name: 'C', location: 'test.ts' });
-        const apply = into('path').positional(0);
-        apply(makeContext([{ raw: '/users', kind: 'literal' }]), draft);
-        expect(draft.path).toEqual('/users');
+        const apply = into('name').positional(0);
+        apply(makeContext([{ raw: 'Renamed', kind: 'literal' }]), draft);
+        expect(draft.name).toEqual('Renamed');
     });
 
     it('positional(i) writes identifier arg into draft key', () => {
         const draft = newControllerDraft({ name: 'C', location: 'test.ts' });
-        const apply = into('path').positional(0);
-        apply(makeContext([{ raw: '/x', kind: 'identifier' }]), draft);
-        expect(draft.path).toEqual('/x');
+        const apply = into('name').positional(0);
+        apply(makeContext([{ raw: 'Ident', kind: 'identifier' }]), draft);
+        expect(draft.name).toEqual('Ident');
     });
 
     it('positional(i) skips when arg is unresolvable', () => {
         const draft = newControllerDraft({ name: 'C', location: 'test.ts' });
-        const apply = into('path').positional(0);
+        const apply = into('name').positional(0);
         apply(makeContext([{ raw: undefined, kind: 'unresolvable' }]), draft);
-        expect(draft.path).toBeUndefined();
+        expect(draft.name).toEqual('C');
     });
 
     it('positional(i) does nothing when arg is missing', () => {
         const draft = newControllerDraft({ name: 'C', location: 'test.ts' });
-        const apply = into('path').positional(0);
+        const apply = into('name').positional(0);
         apply(makeContext([]), draft);
-        expect(draft.path).toBeUndefined();
+        expect(draft.name).toEqual('C');
     });
 
     it('typeArgument writes resolved type into draft key', () => {
@@ -118,8 +118,8 @@ describe('append', () => {
 
     it('throws when existing key holds a non-array value', () => {
         const draft = newControllerDraft({ name: 'C', location: 'test.ts' });
-        (draft as Record<string, unknown>).path = '/scalar';
-        const apply = append('path').positional(0);
+        (draft as Record<string, unknown>).name = 'scalar';
+        const apply = append('name').positional(0);
         expect(() => apply(makeContext([{ raw: 'x', kind: 'literal' }]), draft))
             .toThrow(/not an array/);
     });

--- a/packages/metadata/test/unit/decorator/orchestrator.spec.ts
+++ b/packages/metadata/test/unit/decorator/orchestrator.spec.ts
@@ -56,14 +56,14 @@ describe('applyDecoratorHandlers', () => {
                 apply: (ctx, d) => {
                     const arg = ctx.argument(0);
                     if (arg && arg.kind === 'literal') {
-                        d.path = arg.raw as string;
+                        d.paths = [arg.raw as string];
                     }
                 },
             },
         ];
 
         applyDecoratorHandlers(node, handlers, draft, options('UsersController'));
-        expect(draft.path).toEqual('/users');
+        expect(draft.paths).toEqual(['/users']);
     });
 
     it('skips when no handler matches', () => {
@@ -75,7 +75,7 @@ describe('applyDecoratorHandlers', () => {
         ];
 
         applyDecoratorHandlers(node, handlers, draft, options('C'));
-        expect(draft.path).toBeUndefined();
+        expect(draft.paths).toBeUndefined();
     });
 
     it('runs all matching handlers in registry order (additive)', () => {
@@ -147,7 +147,7 @@ describe('applyDecoratorHandlers', () => {
         const draft = newControllerDraft({ name: 'C', location: 'sample.ts' });
 
         applyDecoratorHandlers(node, [], draft, options('C'));
-        expect(draft.path).toBeUndefined();
+        expect(draft.paths).toBeUndefined();
     });
 
     it('does nothing when node has no decorators', () => {
@@ -159,7 +159,7 @@ describe('applyDecoratorHandlers', () => {
         ];
 
         applyDecoratorHandlers(node, handlers, draft, options('C'));
-        expect(draft.path).toBeUndefined();
+        expect(draft.paths).toBeUndefined();
     });
 });
 

--- a/packages/metadata/test/unit/generator/complex-types.spec.ts
+++ b/packages/metadata/test/unit/generator/complex-types.spec.ts
@@ -201,7 +201,7 @@ describe('complex type metadata extraction', () => {
                 (c) => c.name === 'ComplexTypesController',
             )!;
             expect(controller).toBeDefined();
-            expect(controller.path).toEqual('complex');
+            expect(controller.paths).toEqual(['complex']);
 
             const methodNames = controller.methods.map((m) => m.name);
             expect(methodNames).toContain('getTree');

--- a/packages/metadata/test/unit/generator/controller.spec.ts
+++ b/packages/metadata/test/unit/generator/controller.spec.ts
@@ -85,7 +85,7 @@ describe('controller metadata extraction', () => {
                     (c) => c.name === name,
                 );
                 expect(controller, `controller ${name} should exist`).toBeDefined();
-                expect(controller!.path).toEqual(expectedPath);
+                expect(controller!.paths).toEqual([expectedPath]);
             }
         });
 
@@ -94,8 +94,9 @@ describe('controller metadata extraction', () => {
                 (c) => c.name === 'ParameterizedEndpoint',
             )!;
             expect(controller).toBeDefined();
-            expect(controller.path).toContain('parameterized');
-            expect(controller.path).toContain(':objectId');
+            expect(controller.paths).toHaveLength(1);
+            expect(controller.paths[0]).toContain('parameterized');
+            expect(controller.paths[0]).toContain(':objectId');
         });
     });
 
@@ -210,7 +211,7 @@ describe('controller metadata extraction', () => {
                 (c) => c.name === 'AbstractEntityEndpoint',
             )!;
             expect(abstractEndpoint).toBeDefined();
-            expect(abstractEndpoint.path).toEqual('abstract');
+            expect(abstractEndpoint.paths).toEqual(['abstract']);
         });
     });
 

--- a/packages/metadata/test/unit/generator/metadata.spec.ts
+++ b/packages/metadata/test/unit/generator/metadata.spec.ts
@@ -90,8 +90,8 @@ describe('src/generator/metadata', () => {
         expect(controller).toHaveProperty('name');
         expect(controller.name).toEqual('TestUnionType');
 
-        expect(controller).toHaveProperty('path');
-        expect(controller.path).toEqual('unionTypes');
+        expect(controller).toHaveProperty('paths');
+        expect(controller.paths).toEqual(['unionTypes']);
 
         expect(controller).toHaveProperty('produces');
         expect(controller.produces.length).toEqual(0);

--- a/packages/metadata/test/unit/generator/multi-mount.spec.ts
+++ b/packages/metadata/test/unit/generator/multi-mount.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Metadata } from '../../../src';
+import { generateMetadata } from '../../../src';
+
+describe('multi-mount controller paths', () => {
+    let metadata: Metadata;
+
+    beforeAll(async () => {
+        metadata = await generateMetadata({
+            entryPoint: [{
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../decorators'),
+                pattern: './test/data/controllers/multi-mount.ts',
+            }],
+            cache: false,
+            preset: '@trapi/decorators',
+        });
+    });
+
+    it('should expose every mount path in controller.paths', () => {
+        const controller = metadata.controllers.find((c) => c.name === 'RolesController');
+        expect(controller).toBeDefined();
+        expect(controller!.paths).toEqual(['roles', 'realms/:realmId/roles']);
+    });
+
+    it('should treat path parameters from any mount as valid', () => {
+        // The `detail` method declares @Path('id'), which only appears in the
+        // method-level path '/:id'. Validation should pass against the union
+        // of all controller mounts × method.path.
+        const controller = metadata.controllers.find((c) => c.name === 'RolesController');
+        const detail = controller!.methods.find((m) => m.name === 'detail');
+        expect(detail).toBeDefined();
+        const idParam = detail!.parameters.find((p) => p.name === 'id');
+        expect(idParam).toBeDefined();
+        expect(idParam!.in).toEqual('path');
+    });
+});

--- a/packages/preset-typescript-rest/src/index.ts
+++ b/packages/preset-typescript-rest/src/index.ts
@@ -27,10 +27,24 @@ function readStringArg(ctx: Parameters<ControllerHandler['apply']>[0]): string |
     return undefined;
 }
 
+function readStringOrArrayArg(ctx: Parameters<ControllerHandler['apply']>[0]): string[] | undefined {
+    const single = readStringArg(ctx);
+    if (single !== undefined) return [single];
+    const arg = ctx.argument(0);
+    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+        const out: string[] = [];
+        for (const item of arg.raw) {
+            if (typeof item === 'string') out.push(item);
+        }
+        return out;
+    }
+    return undefined;
+}
+
 const controllerPathHandler = controller({
     match: { name: 'Path', on: 'class' },
     apply: (ctx, draft) => {
-        draft.path = readStringArg(ctx) ?? '';
+        draft.paths = readStringOrArrayArg(ctx) ?? [''];
     },
 });
 

--- a/packages/swagger/src/adapters/generator/v2/module.ts
+++ b/packages/swagger/src/adapters/generator/v2/module.ts
@@ -48,6 +48,20 @@ import { SwaggerError, SwaggerErrorCode } from '../../../core/error';
 import { normalizePathParameters } from '../../../core/utils';
 import { AbstractSpecGenerator } from '../abstract';
 
+function uniqueOperationId(base: string, used: Set<string>): string {
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let counter = 2;
+    while (used.has(`${base}_${counter}`)) {
+        counter += 1;
+    }
+    const candidate = `${base}_${counter}`;
+    used.add(candidate);
+    return candidate;
+}
+
 export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
     async build() : Promise<SpecV2> {
         if (typeof this.spec !== 'undefined') {
@@ -176,6 +190,7 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
 
     private buildPaths() {
         const output: Record<string, Path<OperationV2, ResponseV2>> = {};
+        const usedOperationIds = new Set<string>();
 
         const unique = <T extends unknown[]>(input: T) : T => [...new Set(input)] as T;
 
@@ -184,13 +199,12 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
                 return;
             }
 
+            const controllerPaths = controller.paths.length === 0 ? [''] : controller.paths;
+
             controller.methods.forEach((method) => {
                 if (method.hidden) {
                     return;
                 }
-
-                let fullPath = path.posix.join('/', (controller.path ? controller.path : ''), method.path);
-                fullPath = normalizePathParameters(fullPath);
 
                 method.consumes = unique([...controller.consumes, ...method.consumes]);
                 method.produces = unique([...controller.produces, ...method.produces]);
@@ -199,17 +213,30 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
                 // todo: unique for objects
                 method.responses = unique([...controller.responses, ...method.responses]);
 
-                output[fullPath] = output[fullPath] || {};
-                output[fullPath][method.method] = this.buildMethod(method);
+                for (const controllerPath of controllerPaths) {
+                    let fullPath = path.posix.join('/', controllerPath, method.path);
+                    fullPath = normalizePathParameters(fullPath);
+
+                    output[fullPath] = output[fullPath] || {};
+                    output[fullPath][method.method] = this.buildMethod(method, fullPath, usedOperationIds);
+                }
             });
         });
 
         return output;
     }
 
-    private buildMethod(method: Method) : OperationV2 {
+    private buildMethod(
+        method: Method,
+        emittedPath: string,
+        usedOperationIds: Set<string>,
+    ) : OperationV2 {
         const output = this.buildOperation(method);
         output.consumes = this.buildMethodConsumes(method);
+
+        // Disambiguate operationId across multi-mount controllers (same method
+        // emitted at multiple paths must not share an operationId).
+        output.operationId = uniqueOperationId(output.operationId, usedOperationIds);
 
         output.description = method.description;
         if (method.summary) {
@@ -224,8 +251,12 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
 
         const parameters = this.groupParameters(method.parameters);
 
+        // Filter path-bound params not present in this specific URL template.
+        const pathParams = (parameters[ParameterSource.PATH] || [])
+            .filter((p) => emittedPath.includes(`{${p.name}}`));
+
         output.parameters = [
-            ...(parameters[ParameterSource.PATH] || []),
+            ...pathParams,
             ...(parameters[ParameterSource.QUERY_PROP] || []),
             ...(parameters[ParameterSource.HEADER] || []),
             ...(parameters[ParameterSource.FORM_DATA] || []),

--- a/packages/swagger/src/adapters/generator/v2/module.ts
+++ b/packages/swagger/src/adapters/generator/v2/module.ts
@@ -234,9 +234,11 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
         const output = this.buildOperation(method);
         output.consumes = this.buildMethodConsumes(method);
 
-        // Disambiguate operationId across multi-mount controllers (same method
+        // Prefer an explicit operationId from metadata (matches V3 behaviour),
+        // then disambiguate across multi-mount controllers (the same method
         // emitted at multiple paths must not share an operationId).
-        output.operationId = uniqueOperationId(output.operationId, usedOperationIds);
+        const baseOperationId = method.operationId || output.operationId;
+        output.operationId = uniqueOperationId(baseOperationId, usedOperationIds);
 
         output.description = method.description;
         if (method.summary) {

--- a/packages/swagger/src/adapters/generator/v3/module.ts
+++ b/packages/swagger/src/adapters/generator/v3/module.ts
@@ -71,6 +71,20 @@ const OPENAPI_VERSION_MAP: Partial<Record<`${Version}`, string>> = {
     'v3.2': '3.2.0',
 };
 
+function uniqueOperationId(base: string, used: Set<string>): string {
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let counter = 2;
+    while (used.has(`${base}_${counter}`)) {
+        counter += 1;
+    }
+    const candidate = `${base}_${counter}`;
+    used.add(candidate);
+    return candidate;
+}
+
 export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
     private readonly openApiVersion: string;
 
@@ -155,6 +169,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
 
     private buildPaths() {
         const output: Record<string, Path<OperationV3, ParameterV3>> = {};
+        const usedOperationIds = new Set<string>();
 
         for (let i = 0; i < this.metadata.controllers.length; i++) {
             const controller = this.metadata.controllers[i];
@@ -162,32 +177,48 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                 continue;
             }
 
+            const controllerPaths = controller.paths.length === 0 ? [''] : controller.paths;
+
             for (let j = 0; j < controller.methods.length; j++) {
                 const method = controller.methods[j];
                 if (method.hidden) {
                     continue;
                 }
 
-                let path = removeFinalCharacter(removeDuplicateSlashes(`/${controller.path}/${method.path}`), '/');
-                path = normalizePathParameters(path);
+                for (const controllerPath of controllerPaths) {
+                    let path = removeFinalCharacter(
+                        removeDuplicateSlashes(`/${controllerPath}/${method.path}`),
+                        '/',
+                    );
+                    path = normalizePathParameters(path);
 
-                output[path] = output[path] || {};
-                output[path][method.method] = this.buildMethod(controller.name, method);
+                    output[path] = output[path] || {};
+                    output[path][method.method] = this.buildMethod(controller.name, method, path, usedOperationIds);
+                }
             }
         }
 
         return output;
     }
 
-    private buildMethod(controllerName: string, method: Method) : OperationV3 {
+    private buildMethod(
+        controllerName: string,
+        method: Method,
+        emittedPath: string,
+        usedOperationIds: Set<string>,
+    ) : OperationV3 {
         const output = this.buildOperation(controllerName, method);
 
         output.description = method.description;
         output.summary = method.summary;
         output.tags = method.tags;
 
-        // Use operationId tag otherwise fallback to generate. Warning: This doesn't check uniqueness.
-        output.operationId = method.operationId || output.operationId;
+        // Use the explicit operationId tag if provided, otherwise the generated
+        // one. When the same method is mounted at multiple controller paths the
+        // operationIds collide — disambiguate by suffixing _2, _3, ... so the
+        // emitted spec stays OpenAPI-valid.
+        const baseOperationId = method.operationId || output.operationId;
+        output.operationId = uniqueOperationId(baseOperationId, usedOperationIds);
 
         if (method.deprecated) {
             output.deprecated = method.deprecated;
@@ -199,10 +230,16 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
 
         const parameters = this.groupParameters(method.parameters);
 
+        // Path parameters declared on the method may not all appear in every
+        // controller mount (e.g. /roles vs /realms/:id/roles). Only emit
+        // path-bound params that are present in `emittedPath`.
+        const pathParams = (parameters[ParameterSource.PATH] || [])
+            .filter((p) => emittedPath.includes(`{${p.name}}`));
+
         output.parameters = [
             ...(parameters[ParameterSource.QUERY_PROP] || []),
             ...(parameters[ParameterSource.HEADER] || []),
-            ...(parameters[ParameterSource.PATH] || []),
+            ...pathParams,
             ...(parameters[ParameterSource.COOKIE] || []),
         ]
             .map((p) => this.buildParameter(p));

--- a/packages/swagger/test/data/metadata.json
+++ b/packages/swagger/test/data/metadata.json
@@ -5,7 +5,6 @@
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/union-type.ts",
       "name": "TestUnionType",
-      "path": "unionTypes",
       "produces": [],
       "responses": [],
       "security": [],
@@ -185,14 +184,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "unionTypes"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/type.ts",
       "name": "TypeEndpoint",
-      "path": "type",
       "produces": [],
       "responses": [],
       "security": [],
@@ -541,14 +542,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "type"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/security.ts",
       "name": "SecureEndpoint",
-      "path": "secure",
       "produces": [],
       "responses": [],
       "security": [
@@ -620,14 +623,16 @@
           "parameters": []
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "secure"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/security-multiple.ts",
       "name": "SuperSecureEndpoint",
-      "path": "supersecure",
       "produces": [],
       "responses": [],
       "security": [],
@@ -661,14 +666,16 @@
           "parameters": []
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "supersecure"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/response-description.ts",
       "name": "ResponseController",
-      "path": "response",
       "produces": [],
       "responses": [
         {
@@ -766,14 +773,16 @@
           "parameters": []
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "response"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/promise-service.ts",
       "name": "PromiseService",
-      "path": "promise",
       "produces": [],
       "responses": [],
       "security": [],
@@ -1523,14 +1532,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "promise"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/primitives.ts",
       "name": "PrimitiveEndpoint",
-      "path": "primitives",
       "produces": [],
       "responses": [],
       "security": [],
@@ -1934,14 +1945,16 @@
           "parameters": []
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "primitives"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/parameterized.ts",
       "name": "ParameterizedEndpoint",
-      "path": "parameterized/:objectId",
       "produces": [],
       "responses": [],
       "security": [],
@@ -2079,14 +2092,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "parameterized/:objectId"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/my-service.ts",
       "name": "MyService",
-      "path": "mypath",
       "produces": [],
       "responses": [],
       "security": [],
@@ -2943,14 +2958,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "mypath"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/generic-return.ts",
       "name": "DerivedEndpoint2",
-      "path": "generics2",
       "produces": [],
       "responses": [],
       "security": [],
@@ -3046,14 +3063,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "generics2"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/derived-endpoint.ts",
       "name": "DerivedEndpoint",
-      "path": "generics1",
       "produces": [],
       "responses": [],
       "security": [],
@@ -3101,14 +3120,16 @@
           ]
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "generics1"
+      ]
     },
     {
       "consumes": [],
       "hidden": false,
       "location": "C:/Data/Projects/tada5hi/repositories/trapi/packages/decorators/test/data/controllers/abstract.ts",
       "name": "AbstractEntityEndpoint",
-      "path": "abstract",
       "produces": [],
       "responses": [],
       "security": [],
@@ -3214,7 +3235,10 @@
           "parameters": []
         }
       ],
-      "extensions": []
+      "extensions": [],
+      "paths": [
+        "abstract"
+      ]
     }
   ],
   "referenceTypes": {

--- a/packages/swagger/test/helpers/metadata-builder.ts
+++ b/packages/swagger/test/helpers/metadata-builder.ts
@@ -36,7 +36,7 @@ export function createMetadata(
 }
 
 export function createController(
-    overrides: Partial<Controller> & Pick<Controller, 'name' | 'path' | 'methods'>,
+    overrides: Partial<Controller> & Pick<Controller, 'name' | 'paths' | 'methods'>,
 ): Controller {
     return {
         consumes: [],

--- a/packages/swagger/test/unit/specification/additional-properties.spec.ts
+++ b/packages/swagger/test/unit/specification/additional-properties.spec.ts
@@ -41,7 +41,7 @@ describe('additionalProperties', () => {
         [
             createController({
                 name: 'MapController',
-                path: 'maps',
+                paths: ['maps'],
                 methods: [
                     createMethod({
                         name: 'getStringMap',

--- a/packages/swagger/test/unit/specification/config-variations.spec.ts
+++ b/packages/swagger/test/unit/specification/config-variations.spec.ts
@@ -111,7 +111,7 @@ describe('config variations', () => {
         const metadata = createMetadata([
             createController({
                 name: 'ArrayController',
-                path: 'arrays',
+                paths: ['arrays'],
                 methods: [
                     createMethod({
                         name: 'getWithArray',

--- a/packages/swagger/test/unit/specification/controller-parameter-extensions.spec.ts
+++ b/packages/swagger/test/unit/specification/controller-parameter-extensions.spec.ts
@@ -35,7 +35,7 @@ describe('controller and parameter extensions', () => {
     const metadata = createMetadata([
         createController({
             name: 'TaggedController',
-            path: 'tagged',
+            paths: ['tagged'],
             tags: ['tagged', 'shared'],
             extensions: [
                 { key: 'x-controller', value: 'controller-value' },
@@ -61,7 +61,7 @@ describe('controller and parameter extensions', () => {
         }),
         createController({
             name: 'SharedController',
-            path: 'shared',
+            paths: ['shared'],
             tags: ['shared'],
             extensions: [{ key: 'x-controller', value: 'shared-value' }],
             methods: [
@@ -76,7 +76,7 @@ describe('controller and parameter extensions', () => {
         }),
         createController({
             name: 'PlainController',
-            path: 'plain',
+            paths: ['plain'],
             tags: ['plain'],
             methods: [
                 createMethod({
@@ -175,7 +175,7 @@ describe('controller extensions without declared tags', () => {
     const metadata = createMetadata([
         createController({
             name: 'UntaggedController',
-            path: 'untagged',
+            paths: ['untagged'],
             tags: [],
             extensions: [{ key: 'x-fallback', value: 'value' }],
             methods: [
@@ -216,7 +216,7 @@ describe('hidden controllers and methods', () => {
     const metadata = createMetadata([
         createController({
             name: 'HiddenController',
-            path: 'hidden-controller',
+            paths: ['hidden-controller'],
             hidden: true,
             tags: ['hidden-tag'],
             extensions: [{ key: 'x-hidden', value: 'should-not-appear' }],
@@ -231,7 +231,7 @@ describe('hidden controllers and methods', () => {
         }),
         createController({
             name: 'PartiallyHiddenController',
-            path: 'partial',
+            paths: ['partial'],
             tags: ['partial'],
             methods: [
                 createMethod({
@@ -314,7 +314,7 @@ describe('extensions never overwrite reserved fields', () => {
     const metadata = createMetadata([
         createController({
             name: 'GuardedController',
-            path: 'guarded',
+            paths: ['guarded'],
             tags: ['guarded'],
             // 'name' would collide with Tag.name without the x- prefix guard
             extensions: [{ key: 'name', value: 'should-not-overwrite' }],

--- a/packages/swagger/test/unit/specification/edge-cases.spec.ts
+++ b/packages/swagger/test/unit/specification/edge-cases.spec.ts
@@ -61,7 +61,7 @@ describe('edge cases and spec compliance', () => {
         [
             createController({
                 name: 'EdgeCaseController',
-                path: 'edge',
+                paths: ['edge'],
                 methods: [
                     createMethod({
                         name: 'voidResponse',

--- a/packages/swagger/test/unit/specification/enum-compliance.spec.ts
+++ b/packages/swagger/test/unit/specification/enum-compliance.spec.ts
@@ -50,7 +50,7 @@ describe('enum spec compliance', () => {
         [
             createController({
                 name: 'EnumController',
-                path: 'enums',
+                paths: ['enums'],
                 methods: [
                     createMethod({
                         name: 'get',

--- a/packages/swagger/test/unit/specification/error-paths.spec.ts
+++ b/packages/swagger/test/unit/specification/error-paths.spec.ts
@@ -27,7 +27,7 @@ describe('error paths', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'BadController',
-                    path: 'bad',
+                    paths: ['bad'],
                     methods: [
                         createMethod({
                             name: 'twoBody',
@@ -63,7 +63,7 @@ describe('error paths', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'BadController',
-                    path: 'bad',
+                    paths: ['bad'],
                     methods: [
                         createMethod({
                             name: 'twoBody',
@@ -99,7 +99,7 @@ describe('error paths', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'ConflictController',
-                    path: 'conflict',
+                    paths: ['conflict'],
                     methods: [
                         createMethod({
                             name: 'bodyAndForm',
@@ -135,7 +135,7 @@ describe('error paths', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'CookieController',
-                    path: 'cookie',
+                    paths: ['cookie'],
                     methods: [
                         createMethod({
                             name: 'getCookie',
@@ -178,7 +178,7 @@ describe('error paths', () => {
                 [
                     createController({
                         name: 'EnumController',
-                        path: 'enum',
+                        paths: ['enum'],
                         methods: [
                             createMethod({
                                 name: 'get',
@@ -219,7 +219,7 @@ describe('error paths', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'HiddenController',
-                    path: 'hidden',
+                    paths: ['hidden'],
                     methods: [
                         createMethod({
                             name: 'visible',

--- a/packages/swagger/test/unit/specification/file-upload.spec.ts
+++ b/packages/swagger/test/unit/specification/file-upload.spec.ts
@@ -33,7 +33,7 @@ describe('file upload / multipart form data', () => {
         [
             createController({
                 name: 'UploadController',
-                path: 'upload',
+                paths: ['upload'],
                 methods: [
                     createMethod({
                         name: 'singleFile',

--- a/packages/swagger/test/unit/specification/generate-swagger.spec.ts
+++ b/packages/swagger/test/unit/specification/generate-swagger.spec.ts
@@ -37,7 +37,7 @@ describe('generateSwagger', () => {
     const metadata = createMetadata([
         createController({
             name: 'UserController',
-            path: '/users',
+            paths: ['/users'],
             methods: [
                 createMethod({
                     name: 'getUser',

--- a/packages/swagger/test/unit/specification/intersection-types.spec.ts
+++ b/packages/swagger/test/unit/specification/intersection-types.spec.ts
@@ -57,7 +57,7 @@ describe('intersection types', () => {
         [
             createController({
                 name: 'IntersectionController',
-                path: 'intersection',
+                paths: ['intersection'],
                 methods: [
                     createMethod({
                         name: 'get',

--- a/packages/swagger/test/unit/specification/multi-mount.spec.ts
+++ b/packages/swagger/test/unit/specification/multi-mount.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Version, generateSwagger } from '../../../src';
+import {
+    createController,
+    createMetadata,
+    createMethod,
+    createParameter,
+    createResponse,
+    stringType,
+} from '../../helpers/metadata-builder';
+
+const servers = [{ url: '/' }];
+
+describe('multi-mount controller paths', () => {
+    const metadata = createMetadata([
+        createController({
+            name: 'RolesController',
+            paths: ['roles', 'realms/:realmId/roles'],
+            methods: [
+                createMethod({
+                    name: 'list',
+                    method: 'get',
+                    path: '',
+                    responses: [createResponse({ status: '200' })],
+                }),
+                createMethod({
+                    name: 'detail',
+                    method: 'get',
+                    path: ':id',
+                    parameters: [
+                        createParameter({
+                            name: 'id',
+                            in: 'path',
+                            type: stringType(),
+                        }),
+                        // realmId only exists in one of the controller mounts.
+                        createParameter({
+                            name: 'realmId',
+                            in: 'path',
+                            type: stringType(),
+                        }),
+                    ],
+                    responses: [createResponse({ status: '200' })],
+                }),
+            ],
+        }),
+    ]);
+
+    describe('V3', () => {
+        it('emits one path entry per (controllerPath, method) combination', async () => {
+            const spec = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers },
+            });
+            expect(spec.paths).toHaveProperty('/roles');
+            expect(spec.paths).toHaveProperty('/realms/{realmId}/roles');
+            expect(spec.paths).toHaveProperty('/roles/{id}');
+            expect(spec.paths).toHaveProperty('/realms/{realmId}/roles/{id}');
+        });
+
+        it('disambiguates operationId across mounts with a numeric suffix', async () => {
+            const spec = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers },
+            });
+            const first = spec.paths['/roles'].get!.operationId;
+            const second = spec.paths['/realms/{realmId}/roles'].get!.operationId;
+            expect(first).toEqual('List');
+            expect(second).toEqual('List_2');
+        });
+
+        it('only emits path-bound parameters that are present in the URL template', async () => {
+            const spec = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers },
+            });
+
+            const onlyId = (spec.paths['/roles/{id}'].get!.parameters || [])
+                .filter((p) => (p as { in?: string }).in === 'path')
+                .map((p) => (p as { name: string }).name);
+            expect(onlyId).toEqual(['id']);
+
+            const both = (spec.paths['/realms/{realmId}/roles/{id}'].get!.parameters || [])
+                .filter((p) => (p as { in?: string }).in === 'path')
+                .map((p) => (p as { name: string }).name);
+            expect(both.sort()).toEqual(['id', 'realmId']);
+        });
+    });
+
+    describe('V2', () => {
+        it('emits one path entry per (controllerPath, method) combination', async () => {
+            const spec = await generateSwagger({
+                version: Version.V2,
+                metadata,
+                data: { servers },
+            });
+            expect(spec.paths).toHaveProperty('/roles');
+            expect(spec.paths).toHaveProperty('/realms/{realmId}/roles');
+            expect(spec.paths).toHaveProperty('/roles/{id}');
+            expect(spec.paths).toHaveProperty('/realms/{realmId}/roles/{id}');
+        });
+
+        it('disambiguates operationId across mounts with a numeric suffix', async () => {
+            const spec = await generateSwagger({
+                version: Version.V2,
+                metadata,
+                data: { servers },
+            });
+            const first = spec.paths['/roles'].get!.operationId;
+            const second = spec.paths['/realms/{realmId}/roles'].get!.operationId;
+            expect(first).toEqual('List');
+            expect(second).toEqual('List_2');
+        });
+    });
+});

--- a/packages/swagger/test/unit/specification/multiple-responses.spec.ts
+++ b/packages/swagger/test/unit/specification/multiple-responses.spec.ts
@@ -46,7 +46,7 @@ describe('multiple response status codes', () => {
         [
             createController({
                 name: 'UserController',
-                path: 'users',
+                paths: ['users'],
                 methods: [
                     createMethod({
                         name: 'getUser',

--- a/packages/swagger/test/unit/specification/never-type.spec.ts
+++ b/packages/swagger/test/unit/specification/never-type.spec.ts
@@ -41,7 +41,7 @@ describe('never type in swagger output (#778)', () => {
         [
             createController({
                 name: 'NeverController',
-                path: 'never',
+                paths: ['never'],
                 methods: [
                     createMethod({
                         name: 'alwaysThrows',

--- a/packages/swagger/test/unit/specification/nullable-types.spec.ts
+++ b/packages/swagger/test/unit/specification/nullable-types.spec.ts
@@ -74,7 +74,7 @@ describe('nullable types', () => {
         [
             createController({
                 name: 'NullableController',
-                path: 'nullable',
+                paths: ['nullable'],
                 methods: [
                     createMethod({
                         name: 'get',

--- a/packages/swagger/test/unit/specification/ref-sibling-properties.spec.ts
+++ b/packages/swagger/test/unit/specification/ref-sibling-properties.spec.ts
@@ -70,7 +70,7 @@ describe('$ref sibling properties', () => {
         [
             createController({
                 name: 'PersonController',
-                path: 'person',
+                paths: ['person'],
                 methods: [
                     createMethod({
                         name: 'get',

--- a/packages/swagger/test/unit/specification/schema-validation.spec.ts
+++ b/packages/swagger/test/unit/specification/schema-validation.spec.ts
@@ -66,7 +66,7 @@ describe('OAI schema validation', () => {
             [
                 createController({
                     name: 'UserController',
-                    path: 'users',
+                    paths: ['users'],
                     methods: [
                         createMethod({
                             name: 'getUsers',
@@ -175,7 +175,7 @@ describe('OAI schema validation', () => {
             [
                 createController({
                     name: 'ComplexController',
-                    path: 'complex',
+                    paths: ['complex'],
                     methods: [
                         createMethod({
                             name: 'getWithEnum',
@@ -292,7 +292,7 @@ describe('OAI schema validation', () => {
                 [
                     createController({
                         name: 'ItemController',
-                        path: 'items',
+                        paths: ['items'],
                         methods: [
                             createMethod({
                                 name: 'getItems',
@@ -373,7 +373,7 @@ describe('OAI schema validation', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'SecureController',
-                    path: 'secure',
+                    paths: ['secure'],
                     security: [{ bearerAuth: [] }],
                     methods: [
                         createMethod({
@@ -404,7 +404,7 @@ describe('OAI schema validation', () => {
             const metadata = createMetadata([
                 createController({
                     name: 'SecureController',
-                    path: 'secure',
+                    paths: ['secure'],
                     security: [{ bearerAuth: [] }],
                     methods: [
                         createMethod({

--- a/packages/swagger/test/unit/specification/security-schemes.spec.ts
+++ b/packages/swagger/test/unit/specification/security-schemes.spec.ts
@@ -67,7 +67,7 @@ describe('security schemes', () => {
         [
             createController({
                 name: 'SecureController',
-                path: 'secure',
+                paths: ['secure'],
                 security: [{ bearerAuth: [] }],
                 methods: [
                     createMethod({

--- a/packages/swagger/test/unit/specification/union-composition.spec.ts
+++ b/packages/swagger/test/unit/specification/union-composition.spec.ts
@@ -55,7 +55,7 @@ describe('union composition (oneOf / discriminator)', () => {
         [
             createController({
                 name: 'CompositionController',
-                path: 'composition',
+                paths: ['composition'],
                 methods: [
                     createMethod({
                         name: 'getResult',
@@ -289,7 +289,7 @@ describe('discriminator with refAlias members (#783)', () => {
         [
             createController({
                 name: 'AliasController',
-                path: 'alias',
+                paths: ['alias'],
                 methods: [
                     createMethod({
                         name: 'getShape',
@@ -362,7 +362,7 @@ describe('discriminator with refAlias wrapping nestedObjectLiteral (#783)', () =
         [
             createController({
                 name: 'InlineController',
-                path: 'inline',
+                paths: ['inline'],
                 methods: [
                     createMethod({
                         name: 'getShape',
@@ -430,7 +430,7 @@ describe('discriminator with mixed refObject + refAlias members (#783)', () => {
         [
             createController({
                 name: 'MixedController',
-                path: 'mixed',
+                paths: ['mixed'],
                 methods: [
                     createMethod({
                         name: 'getShape',


### PR DESCRIPTION
…ontroller

BREAKING CHANGE: multi path support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Controllers can now be mounted on multiple base paths, allowing a single controller to serve multiple routes simultaneously.
  * Decorator path arguments now support both single strings and arrays of strings for flexible route configuration.

* **Chores**
  * Cache schema version updated; existing cached metadata will be regenerated on next use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->