### PR TITLE
feat: preset-author helpers + controller-level deprecation

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -81,6 +81,20 @@ export type ParamKind = typeof ParamKind[keyof typeof ParamKind];
 - **Inside this codebase, prefer the const reference** — it's discoverable in IDE autocomplete and shows up in find-all-references. Bare literals are reserved for places where the value is genuinely incidental (e.g. JSDoc tag matching against arbitrary user input).
 - **Don't use TypeScript `enum`s** for new code. They're heavier (compile to JS objects with reverse mappings), don't pattern-match like `as const`, and often mismatch the template-literal type ergonomics. Existing enums have been migrated to the same-name pattern above; `` `${ParameterSource}` ``, `` `${MethodName}` ``, and `` `${CollectionFormat}` `` continue to work unchanged.
 
+### Pitfall: value access inside template-literal types
+
+Property access like `Version.V2` only works in **value** position. Inside template-literal types (`` `${...}` ``), the `Version` identifier resolves to the **type** alias — which is a string-literal union with no `.V2` member. The compiler reports `'Version' only refers to a type, but is being used as a namespace here.`
+
+```ts
+// ❌ Doesn't compile — `Version.V2` is value access in type position.
+type Out<V extends `${Version}`> = V extends `${Version.V2}` ? SpecV2 : SpecV3;
+
+// ✅ Use `typeof Const.MEMBER` to get the literal type.
+type Out<V extends `${Version}`> = V extends typeof Version.V2 ? SpecV2 : SpecV3;
+```
+
+For reusable wrappers, prefer the type helpers exported alongside the const (e.g. `OutputForVersion<V>` for `Version`) over re-deriving the conditional.
+
 ## File Organization
 
 - **`types.ts`** — Only types and interfaces. No functions, no classes, no constants. Every directory that has types uses `types.ts` (not `type.ts`).

--- a/packages/docs/src/guide/framework-integration.md
+++ b/packages/docs/src/guide/framework-integration.md
@@ -154,3 +154,30 @@ The typical pattern is to run metadata generation in a build step, commit the ge
 ```
 
 Pair with [caching](/guide/metadata-caching) to keep repeated runs fast during local development.
+
+## Type ownership reference
+
+Wrapper packages typically need to forward types from `@trapi/metadata` and `@trapi/swagger` through their public API. The split is by lifecycle stage — types describing source extraction live in `@trapi/metadata`; types describing OpenAPI emission live in `@trapi/swagger`.
+
+| Type | Package | What it describes |
+|---|---|---|
+| `Metadata` | `@trapi/metadata` | The full metadata document — controllers, methods, parameters, type references. The output of `generateMetadata()`. |
+| `MetadataGenerateOptions` | `@trapi/metadata` | Input options for `generateMetadata()` — entry point, preset, tsconfig, cache, strict mode. |
+| `Controller`, `Method`, `Parameter` | `@trapi/metadata` | The public, post-orchestrator metadata shapes (mutable drafts have `Draft` suffix and live in the same package). |
+| `Preset`, `Registry` | `@trapi/metadata` | Preset declaration and the flattened post-`extends` form. |
+| `ControllerHandler`, `MethodHandler`, `ParameterHandler` | `@trapi/metadata` | Handler signatures and the `controller(...)` / `method(...)` / `parameter(...)` builders. |
+| `HandlerContext`, `JsDocHandlerContext` | `@trapi/metadata` | What a handler's `apply` callback receives — `argument(i)`, `typeArgument(i)`, `parameterType()`. |
+| `DecoratorArgument`, `DecoratorTypeArgument`, `DecoratorSource` | `@trapi/metadata` | The AST-extraction shape handlers consume. |
+| `MarkerName`, `NumericKind`, `ParamKind`, `CollectionKind` | `@trapi/metadata` | Const objects + same-name type aliases for closed enumerations. |
+| `TsConfig`, `TsCompilerOptions` | `@trapi/metadata` | Wrapper around the typescript compiler-options shape. |
+| `readString`, `readNumber`, `readBoolean`, `readStringOrStringArray` | `@trapi/metadata` | Argument readers shared across presets. |
+| `setControllerPaths`, `setMethodPath` | `@trapi/metadata` | Path-assignment helpers covering the singular-vs-plural asymmetry. |
+| `createHandlerContext`, `literalArg`, `arrayArg`, `objectArg`, `identifierArg`, `unresolvableArg`, `typeArg` | `@trapi/metadata` | Test helpers for unit-testing handlers without spinning up the compiler. |
+| `SwaggerGenerateOptions`, `SwaggerGenerateData` | `@trapi/swagger` | Input options for `generateSwagger()` — version, metadata, document data. |
+| `SpecV2`, `SpecV3` | `@trapi/swagger` | Output OpenAPI specification shapes (`SpecV3` covers 3.0 / 3.1 / 3.2). |
+| `Version` | `@trapi/swagger` | Const + same-name type for the supported OpenAPI versions. Use `typeof Version.V2` (not `` `${Version.V2}` ``) inside template-literal types. |
+| `OutputForVersion<V>` | `@trapi/swagger` | Type helper — resolves to `SpecV2` for `V2`, `SpecV3` otherwise. Use it to type wrapper return values that depend on the requested version. |
+| `DocumentFormat`, `SecurityType` | `@trapi/swagger` | Const objects for output formats and security scheme kinds. |
+| `saveSwagger` | `@trapi/swagger` | Optional file-writer separate from `generateSwagger()`. |
+
+Rule of thumb: if the type describes something *before* the spec exists (source files, decorator handlers, type resolution), it lives in `@trapi/metadata`. If it describes the OpenAPI document itself or how it's emitted, it lives in `@trapi/swagger`.

--- a/packages/metadata/src/adapters/decorator/helpers.ts
+++ b/packages/metadata/src/adapters/decorator/helpers.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ControllerDraft,
+    DecoratorArgument,
+    MethodDraft,
+} from './types';
+
+/**
+ * Read a positional argument as a string. Accepts both literal string args
+ * (`@Foo('value')`) and identifier references that resolve to a string
+ * (`@Foo(SOME_CONSTANT)`). Returns `undefined` for any other argument shape.
+ */
+export function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+/**
+ * Read a positional argument as a number. Only matches numeric literals.
+ */
+export function readNumber(arg: DecoratorArgument | undefined): number | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'number') return arg.raw;
+    return undefined;
+}
+
+/**
+ * Read a positional argument as a boolean. Only matches boolean literals.
+ */
+export function readBoolean(arg: DecoratorArgument | undefined): boolean | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'boolean') return arg.raw;
+    return undefined;
+}
+
+/**
+ * Read a positional argument that may be either a single string or an array
+ * of strings. Returns `undefined` when the argument is missing, when any
+ * array element is non-string, or otherwise unresolvable. All-or-nothing:
+ * never returns a partial array with non-string items silently dropped.
+ */
+export function readStringOrStringArray(
+    arg: DecoratorArgument | undefined,
+): string[] | undefined {
+    const single = readString(arg);
+    if (single !== undefined) {
+        return [single];
+    }
+    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+        if (arg.raw.every((item) => typeof item === 'string')) {
+            return arg.raw;
+        }
+        return undefined;
+    }
+    return undefined;
+}
+
+/**
+ * Convenience for the common controller path assignment. Reads the first
+ * argument as a string-or-string-array and writes it to `draft.paths`,
+ * defaulting to `['']` when the argument is missing or unresolvable. Use this
+ * inside a `controller({ match, apply })` handler to declare a class as a
+ * controller.
+ */
+export function setControllerPaths(
+    draft: ControllerDraft,
+    arg: DecoratorArgument | undefined,
+): void {
+    draft.paths = readStringOrStringArray(arg) ?? [''];
+}
+
+/**
+ * Convenience for the common method path assignment. Reads the first argument
+ * as a string and writes it to `draft.path` if present; leaves the field
+ * untouched otherwise (the orchestrator initialises it to `''`).
+ */
+export function setMethodPath(
+    draft: MethodDraft,
+    arg: DecoratorArgument | undefined,
+): void {
+    const path = readString(arg);
+    if (path !== undefined) {
+        draft.path = path;
+    }
+}

--- a/packages/metadata/src/adapters/decorator/index.ts
+++ b/packages/metadata/src/adapters/decorator/index.ts
@@ -6,7 +6,9 @@
  */
 
 export * from './constants';
+export * from './helpers';
 export * from './module';
+export * from './test-helpers';
 export * from './orchestrator';
 export * from './types';
 export * from './typescript';

--- a/packages/metadata/src/adapters/decorator/test-helpers.ts
+++ b/packages/metadata/src/adapters/decorator/test-helpers.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Type } from '../../core/resolver/types';
+import type {
+    DecoratorArgument,
+    DecoratorHost,
+    DecoratorTypeArgument,
+    HandlerContext,
+} from './types';
+
+/**
+ * Build a literal-kind {@link DecoratorArgument} from a primitive value.
+ * Use this in unit tests to feed handlers a mock argument:
+ *
+ * ```ts
+ * const ctx = createHandlerContext({ args: [literalArg('users')] });
+ * controllerHandler.apply(ctx, draft);
+ * ```
+ */
+export function literalArg(raw: string | number | boolean | null): DecoratorArgument {
+    return { kind: 'literal', raw };
+}
+
+/**
+ * Build an identifier-kind {@link DecoratorArgument} (e.g. `@Foo(SOME_CONSTANT)`).
+ * `raw` is the resolved value the identifier points to — typically a string.
+ */
+export function identifierArg(raw: unknown): DecoratorArgument {
+    return { kind: 'identifier', raw };
+}
+
+/**
+ * Build an array-kind {@link DecoratorArgument} (e.g. `@Foo(['a', 'b'])`).
+ */
+export function arrayArg(raw: unknown[]): DecoratorArgument {
+    return { kind: 'array', raw };
+}
+
+/**
+ * Build an object-kind {@link DecoratorArgument} (e.g. `@Foo({ key: 'value' })`).
+ */
+export function objectArg(raw: Record<string, unknown>): DecoratorArgument {
+    return { kind: 'object', raw };
+}
+
+/**
+ * Build an unresolvable-kind {@link DecoratorArgument} — represents arguments
+ * the source extractor couldn't statically evaluate (e.g. function calls,
+ * unknown identifiers).
+ */
+export function unresolvableArg(): DecoratorArgument {
+    return { kind: 'unresolvable', raw: undefined };
+}
+
+/**
+ * Build a {@link DecoratorTypeArgument} stub that returns the supplied type
+ * when `resolve()` is called.
+ */
+export function typeArg(type: Type): DecoratorTypeArgument {
+    return { resolve: () => type };
+}
+
+export type CreateHandlerContextInput = {
+    args?: DecoratorArgument[];
+    typeArgs?: DecoratorTypeArgument[];
+    host?: DecoratorHost;
+    parameterType?: Type;
+};
+
+/**
+ * Construct a {@link HandlerContext} for unit-testing handlers in isolation
+ * without spinning up the full TypeScript compiler / `generateMetadata`
+ * pipeline. Combine with the `*Arg(...)` builders to feed a handler a
+ * controlled mock decorator source.
+ *
+ * ```ts
+ * const ctx = createHandlerContext({ args: [literalArg('users')] });
+ * const draft = newControllerDraft({ name: 'UserController', location: '/x.ts' });
+ * myHandler.apply(ctx, draft);
+ * expect(draft.paths).toEqual(['users']);
+ * ```
+ */
+export function createHandlerContext(input: CreateHandlerContextInput = {}): HandlerContext {
+    const args = input.args ?? [];
+    const typeArgs = input.typeArgs ?? [];
+    return {
+        host: input.host ?? { name: 'TestHost' },
+        argument: (index) => args[index],
+        arguments: () => [...args],
+        typeArgument: (index) => typeArgs[index],
+        typeArguments: () => [...typeArgs],
+        parameterType: () => input.parameterType,
+    };
+}

--- a/packages/metadata/src/adapters/decorator/types.ts
+++ b/packages/metadata/src/adapters/decorator/types.ts
@@ -79,6 +79,7 @@ export type ControllerDraft = {
     location: string;
     paths?: string[];
     hidden: boolean;
+    deprecated?: boolean;
     consumes: string[];
     produces: string[];
     tags: string[];

--- a/packages/metadata/src/app/generator/controller/module.ts
+++ b/packages/metadata/src/app/generator/controller/module.ts
@@ -91,6 +91,7 @@ export class ControllerGenerator implements IControllerGenerator {
 
         return {
             consumes: draft.consumes,
+            deprecated: draft.deprecated,
             extensions: draft.extensions,
             hidden: draft.hidden,
             location: draft.location,

--- a/packages/metadata/src/core/controller/types.ts
+++ b/packages/metadata/src/core/controller/types.ts
@@ -18,6 +18,14 @@ export type Controller = {
     consumes: string[];
 
     /**
+     * Whether every operation under this controller should be considered
+     * deprecated. OpenAPI has no controller-level `deprecated` field — emitters
+     * should cascade this flag to each emitted operation (combined with the
+     * method's own `deprecated`).
+     */
+    deprecated?: boolean;
+
+    /**
      * Vendor extensions (x-* keys) declared on the controller class.
      */
     extensions: Extension[];

--- a/packages/metadata/test/unit/decorator/helpers.spec.ts
+++ b/packages/metadata/test/unit/decorator/helpers.spec.ts
@@ -9,8 +9,8 @@ import { describe, expect, it } from 'vitest';
 import {
     type DecoratorArgument,
     type DecoratorTypeArgument,
-    type HandlerContext,
     append,
+    createHandlerContext,
     flag,
     into,
     newControllerDraft,
@@ -19,15 +19,8 @@ import {
 } from '../../../src/adapters/decorator';
 import type { Type } from '../../../src/core/resolver/types';
 
-function makeContext(args: DecoratorArgument[], typeArgs: DecoratorTypeArgument[] = []): HandlerContext {
-    return {
-        host: { name: 'TestHost' },
-        argument: (i) => args[i],
-        arguments: () => args,
-        typeArgument: (i) => typeArgs[i],
-        typeArguments: () => typeArgs,
-        parameterType: () => undefined,
-    };
+function makeContext(args: DecoratorArgument[], typeArgs: DecoratorTypeArgument[] = []) {
+    return createHandlerContext({ args, typeArgs });
 }
 
 describe('into', () => {

--- a/packages/metadata/test/unit/decorator/test-helpers.spec.ts
+++ b/packages/metadata/test/unit/decorator/test-helpers.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    MarkerName,
+    arrayArg,
+    controller,
+    createHandlerContext,
+    identifierArg,
+    literalArg,
+    newControllerDraft,
+    newMethodDraft,
+    objectArg,
+    setControllerPaths,
+    setMethodPath,
+    typeArg,
+    unresolvableArg,
+} from '../../../src/adapters/decorator';
+import type { Type } from '../../../src/core/resolver/types';
+
+const setHidden = (
+    _ctx: { argument: (i: number) => unknown },
+    draft: { hidden: boolean },
+) => {
+    draft.hidden = true;
+};
+
+describe('test-helpers', () => {
+    it('createHandlerContext exposes args and typeArgs', () => {
+        const ctx = createHandlerContext({
+            args: [literalArg('users'), literalArg(42)],
+            typeArgs: [typeArg({ typeName: 'string' } as Type)],
+        });
+
+        expect(ctx.argument(0)?.raw).toBe('users');
+        expect(ctx.argument(1)?.raw).toBe(42);
+        expect(ctx.argument(2)).toBeUndefined();
+        expect(ctx.arguments()).toHaveLength(2);
+        expect(ctx.typeArgument(0)?.resolve()).toEqual({ typeName: 'string' });
+        expect(ctx.typeArguments()).toHaveLength(1);
+    });
+
+    it('createHandlerContext defaults to empty args / TestHost', () => {
+        const ctx = createHandlerContext();
+        expect(ctx.argument(0)).toBeUndefined();
+        expect(ctx.arguments()).toEqual([]);
+        expect(ctx.host.name).toBe('TestHost');
+    });
+
+    it('arg builders produce the expected shapes', () => {
+        expect(literalArg('x')).toEqual({ kind: 'literal', raw: 'x' });
+        expect(identifierArg('CONST')).toEqual({ kind: 'identifier', raw: 'CONST' });
+        expect(arrayArg(['a', 'b'])).toEqual({ kind: 'array', raw: ['a', 'b'] });
+        expect(objectArg({ a: 1 })).toEqual({ kind: 'object', raw: { a: 1 } });
+        expect(unresolvableArg()).toEqual({ kind: 'unresolvable', raw: undefined });
+    });
+
+    it('lets a controller handler be unit-tested in isolation', () => {
+        const handler = controller({
+            match: { name: 'Controller', on: 'class' },
+            apply: (ctx, draft) => {
+                setControllerPaths(draft, ctx.argument(0));
+            },
+        });
+
+        const draft = newControllerDraft({ name: 'UserController', location: '/x.ts' });
+        handler.apply(
+            createHandlerContext({ args: [literalArg('users')] }),
+            draft,
+        );
+
+        expect(draft.paths).toEqual(['users']);
+    });
+
+    it('lets a multi-mount handler be unit-tested', () => {
+        const handler = controller({
+            match: { name: 'Controller', on: 'class' },
+            apply: (ctx, draft) => {
+                setControllerPaths(draft, ctx.argument(0));
+            },
+        });
+
+        const draft = newControllerDraft({ name: 'C', location: '/x.ts' });
+        handler.apply(
+            createHandlerContext({ args: [arrayArg(['/roles', '/realms/:id/roles'])] }),
+            draft,
+        );
+
+        expect(draft.paths).toEqual(['/roles', '/realms/:id/roles']);
+    });
+
+    it('setMethodPath leaves draft unchanged when arg is missing', () => {
+        const draft = newMethodDraft({ name: 'list' });
+        setMethodPath(draft, undefined);
+        expect(draft.path).toBe('');
+    });
+
+    it('round-trips marker metadata declared on the handler', () => {
+        const handler = controller({
+            match: { name: 'Skip', on: 'class' },
+            apply: setHidden,
+            marker: MarkerName.Hidden,
+        });
+
+        expect(handler.marker).toBe('hidden');
+        expect(handler.match.name).toBe('Skip');
+    });
+});

--- a/packages/preset-decorators-express/src/handlers/controller.ts
+++ b/packages/preset-decorators-express/src/handlers/controller.ts
@@ -6,7 +6,12 @@
  */
 
 import type { ControllerHandler } from '@trapi/metadata';
-import { MarkerName, controller } from '@trapi/metadata';
+import {
+    MarkerName,
+    controller,
+    readStringOrStringArray,
+    setControllerPaths,
+} from '@trapi/metadata';
 import {
     appendConsumes,
     appendExtensionToDraft,
@@ -14,7 +19,7 @@ import {
     appendSecurityToDraft,
     appendTags,
     applyDescriptionToDraft,
-    readStringOrStringArray,
+    setDeprecated,
     setHidden,
 } from './shared';
 
@@ -23,8 +28,7 @@ import {
 const controllerControllerHandler = controller({
     match: { name: 'Controller', on: 'class' },
     apply: (ctx, draft) => {
-        const paths = readStringOrStringArray(ctx.argument(0));
-        draft.paths = paths ?? [''];
+        setControllerPaths(draft, ctx.argument(0));
     },
 });
 
@@ -44,6 +48,12 @@ const controllerHiddenHandler = controller({
     match: { name: 'Hidden', on: 'class' },
     apply: setHidden,
     marker: MarkerName.Hidden,
+});
+
+const controllerDeprecatedHandler = controller({
+    match: { name: 'Deprecated', on: 'class' },
+    apply: setDeprecated,
+    marker: MarkerName.Deprecated,
 });
 
 const controllerTagsHandler = controller({
@@ -86,6 +96,7 @@ export const controllerHandlers: ControllerHandler[] = [
     controllerControllerHandler,
     controllerMountHandler,
     controllerHiddenHandler,
+    controllerDeprecatedHandler,
     controllerTagsHandler,
     controllerProducesHandler,
     controllerConsumesHandler,

--- a/packages/preset-decorators-express/src/handlers/method.ts
+++ b/packages/preset-decorators-express/src/handlers/method.ts
@@ -6,7 +6,12 @@
  */
 
 import type { MethodDraft, MethodHandler } from '@trapi/metadata';
-import { MarkerName, method } from '@trapi/metadata';
+import {
+    MarkerName,
+    method,
+    readString,
+    setMethodPath,
+} from '@trapi/metadata';
 import {
     appendConsumes,
     appendExtensionToDraft,
@@ -14,7 +19,6 @@ import {
     appendSecurityToDraft,
     appendTags,
     applyDescriptionToDraft,
-    readString,
     setDeprecated,
     setHidden,
 } from './shared';
@@ -24,10 +28,7 @@ import {
 function setVerbAndPath(verb: MethodDraft['verb']): MethodHandler['apply'] {
     return (ctx, draft) => {
         draft.verb = verb;
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     };
 }
 
@@ -43,20 +44,14 @@ const methodAllHandler = method({
     match: { name: 'All', on: 'method' },
     apply: (ctx, draft) => {
         draft.verb = 'get';
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     },
 });
 
 const methodMountHandler = method({
     match: { name: 'Mount', on: 'method' },
     apply: (ctx, draft) => {
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     },
 });
 

--- a/packages/preset-decorators-express/src/handlers/shared.ts
+++ b/packages/preset-decorators-express/src/handlers/shared.ts
@@ -7,47 +7,17 @@
 
 import type {
     ControllerDraft,
-    DecoratorArgument,
     HandlerContext,
     MethodDraft,
     ParameterDraft,
 } from '@trapi/metadata';
-import { append } from '@trapi/metadata';
+import { append, readNumber, readString } from '@trapi/metadata';
 
-export function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
-
-export function readNumber(arg: DecoratorArgument | undefined): number | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'number') return arg.raw;
-    return undefined;
-}
-
-/**
- * Read a positional argument that may be either a single string or an array
- * of strings. Returns `undefined` when the argument is missing, when any
- * array element is non-string, or otherwise unresolvable. All-or-nothing:
- * never returns a partial array with non-string items silently dropped.
- */
-export function readStringOrStringArray(
-    arg: DecoratorArgument | undefined,
-): string[] | undefined {
-    const single = readString(arg);
-    if (single !== undefined) {
-        return [single];
-    }
-    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
-        if (arg.raw.every((item) => typeof item === 'string')) {
-            return arg.raw;
-        }
-        return undefined;
-    }
-    return undefined;
-}
+export {
+    readNumber,
+    readString,
+    readStringOrStringArray,
+} from '@trapi/metadata';
 
 export const setHidden = (_ctx: HandlerContext, draft: { hidden: boolean }) => {
     draft.hidden = true;

--- a/packages/preset-typescript-rest/src/handlers/markers.ts
+++ b/packages/preset-typescript-rest/src/handlers/markers.ts
@@ -16,13 +16,13 @@ import {
     controller,
     method,
     parameter,
+    setMethodPath,
 } from '@trapi/metadata';
 import {
     appendConsumes,
     appendExtensionToDraft,
     appendProduces,
     appendTags,
-    readString,
     setDeprecated,
     setHidden,
 } from './shared';
@@ -33,6 +33,12 @@ const controllerHiddenHandler = controller({
     match: { name: 'Hidden', on: 'class' },
     apply: setHidden,
     marker: MarkerName.Hidden,
+});
+
+const controllerDeprecatedHandler = controller({
+    match: { name: 'Deprecated', on: 'class' },
+    apply: setDeprecated,
+    marker: MarkerName.Deprecated,
 });
 
 const controllerTagsHandler = controller({
@@ -63,6 +69,7 @@ const controllerExtensionHandler = controller({
 
 export const controllerMarkerHandlers: ControllerHandler[] = [
     controllerHiddenHandler,
+    controllerDeprecatedHandler,
     controllerTagsHandler,
     controllerProducesHandler,
     controllerConsumesHandler,
@@ -75,10 +82,7 @@ export const controllerMarkerHandlers: ControllerHandler[] = [
 const methodMountHandler = method({
     match: { name: 'Mount', on: 'method' },
     apply: (ctx, draft) => {
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     },
 });
 

--- a/packages/preset-typescript-rest/src/handlers/shared.ts
+++ b/packages/preset-typescript-rest/src/handlers/shared.ts
@@ -7,41 +7,13 @@
 
 import type {
     ControllerDraft,
-    DecoratorArgument,
     HandlerContext,
     MethodDraft,
     ParameterDraft,
 } from '@trapi/metadata';
-import { append } from '@trapi/metadata';
+import { append, readString } from '@trapi/metadata';
 
-export function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
-
-/**
- * Read a positional argument that may be either a single string or an array
- * of strings. Returns `undefined` when the argument is missing, when any
- * array element is non-string, or otherwise unresolvable. All-or-nothing:
- * never returns a partial array with non-string items silently dropped.
- */
-export function readStringOrStringArray(
-    arg: DecoratorArgument | undefined,
-): string[] | undefined {
-    const single = readString(arg);
-    if (single !== undefined) {
-        return [single];
-    }
-    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
-        if (arg.raw.every((item) => typeof item === 'string')) {
-            return arg.raw;
-        }
-        return undefined;
-    }
-    return undefined;
-}
+export { readString, readStringOrStringArray } from '@trapi/metadata';
 
 export const setHidden = (_ctx: HandlerContext, draft: { hidden: boolean }) => {
     draft.hidden = true;

--- a/packages/preset-typescript-rest/src/index.ts
+++ b/packages/preset-typescript-rest/src/index.ts
@@ -6,13 +6,15 @@
  */
 
 import {
-    type ControllerHandler,
     type MethodHandler,
     ParamKind,
     type Preset,
     controller,
     method,
     parameter,
+    readString,
+    setControllerPaths,
+    setMethodPath,
 } from '@trapi/metadata';
 import {
     controllerMarkerHandlers,
@@ -29,42 +31,17 @@ import {
 // typescript-rest. We map it to two handlers (one for class, one for method)
 // because the same decorator name is reused for `@Path('/:id')` on methods.
 
-function readStringArg(ctx: Parameters<ControllerHandler['apply']>[0]): string | undefined {
-    const arg = ctx.argument(0);
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
-
-function readStringOrArrayArg(ctx: Parameters<ControllerHandler['apply']>[0]): string[] | undefined {
-    const single = readStringArg(ctx);
-    if (single !== undefined) return [single];
-    const arg = ctx.argument(0);
-    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
-        const out: string[] = [];
-        for (const item of arg.raw) {
-            if (typeof item === 'string') out.push(item);
-        }
-        return out;
-    }
-    return undefined;
-}
-
 const controllerPathHandler = controller({
     match: { name: 'Path', on: 'class' },
     apply: (ctx, draft) => {
-        draft.paths = readStringOrArrayArg(ctx) ?? [''];
+        setControllerPaths(draft, ctx.argument(0));
     },
 });
 
 const methodPathHandler = method({
     match: { name: 'Path', on: 'method' },
     apply: (ctx, draft) => {
-        const path = readStringArg(ctx);
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     },
 });
 
@@ -100,7 +77,7 @@ function paramHandler(name: string, kind: typeof ParamKind[keyof typeof ParamKin
         match: { name, on: 'parameter' },
         apply: (ctx, draft) => {
             draft.in = kind;
-            const argName = readStringArg(ctx);
+            const argName = readString(ctx.argument(0));
             if (argName) draft.name = argName;
         },
     });

--- a/packages/swagger/src/adapters/generator/v2/module.ts
+++ b/packages/swagger/src/adapters/generator/v2/module.ts
@@ -210,6 +210,9 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
                 method.produces = unique([...controller.produces, ...method.produces]);
                 method.tags = unique([...controller.tags, ...method.tags]);
                 method.security = method.security || controller.security;
+                // OpenAPI has no controller-level `deprecated` — cascade
+                // controller deprecation to every emitted operation.
+                method.deprecated = method.deprecated || controller.deprecated;
                 // todo: unique for objects
                 method.responses = unique([...controller.responses, ...method.responses]);
 

--- a/packages/swagger/src/adapters/generator/v3/module.ts
+++ b/packages/swagger/src/adapters/generator/v3/module.ts
@@ -185,6 +185,10 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                     continue;
                 }
 
+                // OpenAPI has no controller-level `deprecated` — cascade
+                // controller deprecation to every emitted operation.
+                method.deprecated = method.deprecated || controller.deprecated;
+
                 for (const controllerPath of controllerPaths) {
                     let path = removeFinalCharacter(
                         removeDuplicateSlashes(`/${controllerPath}/${method.path}`),

--- a/packages/swagger/src/app/module.ts
+++ b/packages/swagger/src/app/module.ts
@@ -9,12 +9,8 @@ import type { Metadata } from '@trapi/metadata';
 import { generateMetadata, isMetadata } from '@trapi/metadata';
 import type { SpecGeneratorOptionsInput, SwaggerGenerateOptions } from '../core/config';
 import { Version } from '../core/constants';
-import type { SpecV2, SpecV3 } from '../core/schema';
+import type { OutputForVersion } from '../core/types';
 import { V2Generator, V3Generator  } from '../adapters/index.ts';
-
-type OutputSpec<V extends `${Version}`> = V extends typeof Version.V2 ?
-    SpecV2 :
-    SpecV3;
 
 function toSpecGeneratorOptionsInput(options: SwaggerGenerateOptions): SpecGeneratorOptionsInput {
     const { data } = options;
@@ -47,7 +43,7 @@ async function resolveMetadata(options: SwaggerGenerateOptions): Promise<Metadat
 
 export async function generateSwagger<V extends `${Version}`>(
     options: Omit<SwaggerGenerateOptions, 'version'> & { version: V },
-): Promise<OutputSpec<V>> {
+): Promise<OutputForVersion<V>> {
     const metadata = await resolveMetadata(options);
     const specGeneratorOptionsInput = toSpecGeneratorOptionsInput(options);
 
@@ -57,12 +53,12 @@ export async function generateSwagger<V extends `${Version}`>(
         case Version.V3_2: {
             const generator = new V3Generator(metadata, specGeneratorOptionsInput, options.version);
 
-            return await generator.build() as OutputSpec<V>;
+            return await generator.build() as OutputForVersion<V>;
         }
         default: {
             const generator = new V2Generator(metadata, specGeneratorOptionsInput);
 
-            return await generator.build() as OutputSpec<V>;
+            return await generator.build() as OutputForVersion<V>;
         }
     }
 }

--- a/packages/swagger/src/core/types.ts
+++ b/packages/swagger/src/core/types.ts
@@ -5,11 +5,29 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { SecurityType } from './constants';
+import type { SecurityType, Version } from './constants';
+import type { SpecV2, SpecV3 } from './schema';
 
 export type ValidatorOpenApiMeta = { kind: 'keyword'; key: string } |
     { kind: 'format'; format: string } |
     { kind: 'ignore' };
+
+/**
+ * Resolves the OpenAPI specification output type for a given `Version`.
+ *
+ * Use this to type wrapper functions around `generateSwagger()` whose return
+ * type depends on the requested `Version`:
+ *
+ * ```ts
+ * type GeneratorOutput<V extends `${Version}`> = OutputForVersion<V>;
+ * ```
+ *
+ * Internally `Version.V2` resolves to `SpecV2`; everything else resolves to
+ * `SpecV3` (which models OpenAPI 3.0, 3.1, and 3.2 — they share a schema).
+ */
+export type OutputForVersion<V extends `${Version}`> = V extends typeof Version.V2 ?
+    SpecV2 :
+    SpecV3;
 
 declare module '@trapi/metadata' {
     interface ValidatorMeta {


### PR DESCRIPTION
## Summary

Addresses design rough edges surfaced while migrating [routup/plugins](https://github.com/routup/plugins) to TRAPI 2.0-beta.

- **Shared argument readers in `@trapi/metadata`** — `readString`, `readNumber`, `readBoolean`, `readStringOrStringArray`. Every preset was reimplementing these; both framework presets and `examples/decorators` now consume the shared exports.
- **Path-assignment helpers** — `setControllerPaths(draft, arg)` and `setMethodPath(draft, arg)` paper over the `Controller.paths: string[]` vs `Method.path: string` asymmetry that's caused at least one silent type-error in a downstream preset (routup's class handler).
- **Handler unit-test API** — `createHandlerContext` plus `literalArg`/`arrayArg`/`objectArg`/`identifierArg`/`unresolvableArg`/`typeArg` builders. Preset authors can now unit-test handlers without spinning up the full TypeScript compiler / `generateMetadata` pipeline.
- **`Controller.deprecated`** — class-level `@Deprecated` is now meaningful. OpenAPI has no controller-level `deprecated` field, so the V2 + V3 emitters cascade the flag onto every emitted operation.
- **`OutputForVersion<V>` in `@trapi/swagger`** — replaces the previously-private `OutputSpec<V>`. Wrappers around `generateSwagger()` no longer need to re-derive the version → spec conditional. Pairs with a new pitfall callout in `.agents/conventions.md` for the `typeof Version.V2` recipe inside template-literal types.
- **Type-ownership reference** — new table in `framework-integration.md` listing every public type and which package owns it.

## Out of scope (deliberately deferred)

- The `HandlerContext.host` leaks the TS-AST shape — flagged but needs a non-TS adapter use case to drive the right abstraction.
- `applyDescriptionToDraft` / `appendSecurityToDraft` are still duplicated between the two framework presets. They're more opinionated (security all-or-nothing policy is a choice) and worth a separate iteration.
- V3 emitter doesn't merge `controller.tags/consumes/produces` onto methods — pre-existing inconsistency with V2, separate from this work.

## Test plan

- [x] `npx nx run-many -t build` — all 6 packages clean
- [x] `npx nx run-many -t test` — 303 metadata (was 296) + 204 swagger + others, all green
- [x] `npm run lint` — clean
- [x] New `test-helpers.spec.ts` exercises the public unit-test API end to end
- [ ] Verify routup/plugins continues to compile against the new exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Controllers can now be marked as deprecated, with deprecation automatically included in generated OpenAPI specifications.

* **Documentation**
  * Added framework integration guide mapping wrapper package types to source packages; clarified TypeScript template-literal type usage.

* **Refactor**
  * Centralized decorator argument parsing and path-setting utilities across modules.

* **Tests**
  * Enhanced test utilities for unit testing decorator handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->