### PR TITLE
feat(metadata): accept inline Preset object or Registry in MetadataGe…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -102,6 +102,14 @@ Neither preset `extends` the other. The repo deliberately ships no shared base p
 
 `examples/decorators/` (private, unpublished) is a worked example of authoring a custom decorator runtime + matching `Preset` from scratch — it covers the same handler families as the framework presets.
 
+**Configuring decorator handlers.** `MetadataGeneratorOptions` accepts handler configuration in three shapes:
+
+- `preset?: string | Preset` — string identifier resolved via `resolvePresetByName` (npm package, relative path, or `module:` specifier), or an inline `Preset` object (still walked through `loadRegistry`, so its `extends` chain — if any — is resolved by name).
+- `registry?: Registry` — already-resolved flat registry; useful for one-off custom handlers without authoring a full `Preset`. Build it with `createRegistry({ controllers: [...], methods: [...] })` — every kind is optional and defaults to `[]`.
+- Both — they merge. The preset-derived registry comes first, the inline `registry` is appended after, so inline handlers run last in the orchestrator (winning on scalar mutations like `into('path')`, additively contributing on `append`-style fields).
+
+Inline `registry` handlers cannot carry `replaces` semantics — those are enforced at preset-load time. To remove a preset handler, author a `Preset` with `replaces` and pass it via `preset` instead. The cache key folds in `preset.name` (when present) and `hashRegistry(merged)`, so toggling either contributor invalidates the cache.
+
 ## Swagger Generator
 
 The swagger emitters live under `adapters/generator/` and share an abstract base:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,7 @@ Packages are libraries published to npm. The `docs` package is a private VitePre
 - **[Architecture](.agents/architecture.md)** — Metadata extraction pipeline, type resolution, and generator patterns
 - **[Testing](.agents/testing.md)** — Vitest setup, coverage thresholds, and test patterns
 - **[Conventions](.agents/conventions.md)** — Commit conventions, linting, CI/CD, and release process
+
+## Commits
+
+- Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.

--- a/packages/metadata/src/adapters/decorator/utils.ts
+++ b/packages/metadata/src/adapters/decorator/utils.ts
@@ -101,14 +101,37 @@ export function newParameterDraft(input: Pick<ParameterDraft, 'parameterName'>):
 // Registry factory
 // -----------------------------------------------------------------------------
 
-export function createRegistry(): Registry {
+/**
+ * Build a {@link Registry}, optionally seeded with handler arrays from `input`.
+ * Any kind omitted from `input` falls back to an empty array, so callers can
+ * pass just the kinds they care about (e.g. `createRegistry({ methods: [...] })`).
+ *
+ * The provided arrays are copied — mutating the result does not affect `input`.
+ */
+export function createRegistry(input: Partial<Registry> = {}): Registry {
     return {
-        controllers: [],
-        methods: [],
-        parameters: [],
-        controllerJsDoc: [],
-        methodJsDoc: [],
-        parameterJsDoc: [],
+        controllers: input.controllers ? [...input.controllers] : [],
+        methods: input.methods ? [...input.methods] : [],
+        parameters: input.parameters ? [...input.parameters] : [],
+        controllerJsDoc: input.controllerJsDoc ? [...input.controllerJsDoc] : [],
+        methodJsDoc: input.methodJsDoc ? [...input.methodJsDoc] : [],
+        parameterJsDoc: input.parameterJsDoc ? [...input.parameterJsDoc] : [],
+    };
+}
+
+/**
+ * Concatenate two registries kind-by-kind. Earlier handlers run first inside
+ * the orchestrator, so callers who want override-by-running-later semantics
+ * should pass the dominant registry as `b`.
+ */
+export function mergeRegistries(a: Registry, b: Registry): Registry {
+    return {
+        controllers: [...a.controllers, ...b.controllers],
+        methods: [...a.methods, ...b.methods],
+        parameters: [...a.parameters, ...b.parameters],
+        controllerJsDoc: [...a.controllerJsDoc, ...b.controllerJsDoc],
+        methodJsDoc: [...a.methodJsDoc, ...b.methodJsDoc],
+        parameterJsDoc: [...a.parameterJsDoc, ...b.parameterJsDoc],
     };
 }
 

--- a/packages/metadata/src/app/generator/metadata/module.ts
+++ b/packages/metadata/src/app/generator/metadata/module.ts
@@ -30,7 +30,13 @@ import {
 } from '../../../adapters/cache';
 import type { MetadataGeneratorOptions } from '../../../core/config';
 import type { Registry, UnmatchedDecoratorReport } from '../../../adapters/decorator';
-import { createRegistry, loadRegistryByName } from '../../../adapters/decorator';
+import {
+    createRegistry,
+    loadRegistry,
+    loadRegistryByName,
+    mergeRegistries,
+    resolvePresetByName,
+} from '../../../adapters/decorator';
 import { ConfigError } from '../../../core/error/config';
 import { ConfigErrorCode } from '../../../core/error/config-codes';
 import { GeneratorError } from '../../../core/error/generator';
@@ -94,8 +100,22 @@ export class MetadataGenerator implements IGeneratorContext, IMetadataGenerator 
         // Load the preset upfront so its resolved registry can contribute to
         // the cache key. Otherwise edits to a local preset (or upgrades that
         // share a name) would silently serve stale metadata.
-        if (this.config.preset) {
-            this.registry = await loadRegistryByName(this.config.preset);
+        let presetRegistry: Registry | undefined;
+        let presetName: string | undefined;
+        if (typeof this.config.preset === 'string') {
+            presetName = this.config.preset;
+            presetRegistry = await loadRegistryByName(this.config.preset);
+        } else if (this.config.preset) {
+            presetName = this.config.preset.name;
+            presetRegistry = await loadRegistry(this.config.preset, { resolver: resolvePresetByName });
+        }
+
+        if (presetRegistry && this.config.registry) {
+            this.registry = mergeRegistries(presetRegistry, this.config.registry);
+        } else if (presetRegistry) {
+            this.registry = presetRegistry;
+        } else if (this.config.registry) {
+            this.registry = this.config.registry;
         }
 
         const cacheKey = composeCacheKey({
@@ -103,7 +123,7 @@ export class MetadataGenerator implements IGeneratorContext, IMetadataGenerator 
             sourceFilesHash,
             compilerOptionsHash: hashCompilerOptions(this.program.getCompilerOptions()),
             registryHash: hashRegistry(this.registry),
-            presetName: this.config.preset,
+            presetName,
         });
 
         // Strict reporting requires handler dispatch to actually run. A cache hit
@@ -144,7 +164,7 @@ export class MetadataGenerator implements IGeneratorContext, IMetadataGenerator 
     }
 
     private assertPresetProducedControllers(): void {
-        if (this.config.preset || this.controllers.length > 0) {
+        if (this.config.preset || this.config.registry || this.controllers.length > 0) {
             return;
         }
         // Only fault a missing preset when we actually scanned source files —
@@ -154,7 +174,7 @@ export class MetadataGenerator implements IGeneratorContext, IMetadataGenerator 
             return;
         }
         throw new ConfigError({
-            message: 'No preset configured and no controllers detected. Provide `preset: \'@trapi/preset-decorators-express\'` (or another preset) so handlers can match your decorators.',
+            message: 'No preset or registry configured and no controllers detected. Provide `preset: \'@trapi/preset-decorators-express\'` (or another preset), or pass an inline `registry`, so handlers can match your decorators.',
             code: ConfigErrorCode.PRESET_MISSING,
         });
     }

--- a/packages/metadata/src/core/config/types.ts
+++ b/packages/metadata/src/core/config/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CacheOptions } from '../../adapters/cache';
-import type { UnmatchedDecoratorReport } from '../../adapters/decorator';
+import type { Preset, Registry, UnmatchedDecoratorReport } from '../../adapters/decorator';
 import type { TsConfig } from '../../adapters/filesystem/tsconfig';
 
 export type EntryPointOptions = {
@@ -41,9 +41,30 @@ export type MetadataGeneratorOptions = {
     cache?: string | boolean | Partial<CacheOptions>;
 
     /**
-     * Load a specific preset configuration.
+     * Decorator preset to load. Either:
+     * - a string identifier resolved via {@link resolvePresetByName}
+     *   (npm package, relative path, or `module:` specifier), or
+     * - an inline {@link Preset} object (still walked through `loadRegistry`,
+     *   so its `extends` chain — if any — is resolved by name).
+     *
+     * If both `preset` and `registry` are provided, the resolved preset
+     * registry comes first and the inline `registry` is appended after.
+     * Inline handlers therefore run last (winning on scalar mutations like
+     * `into('path')`) and additively contribute on `append`-style fields.
      */
-    preset?: string;
+    preset?: string | Preset;
+
+    /**
+     * An already-resolved decorator {@link Registry}. Use this to wire
+     * decorator handlers manually without authoring a full {@link Preset}.
+     *
+     * If provided alongside `preset`, the registry is appended to the
+     * preset-derived registry (preset first, registry second). Inline
+     * handlers cannot carry `replaces` semantics — those are enforced at
+     * preset-load time. To remove a preset handler, author a `Preset` with
+     * `replaces` and pass it via `preset` instead.
+     */
+    registry?: Registry;
 
     /**
      * Controls how unmatched decorators (decorators with no matching handler

--- a/packages/metadata/test/data/inline-registry/controller.ts
+++ b/packages/metadata/test/data/inline-registry/controller.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Controller, Get } from '../_stubs';
+
+@Controller('/widgets')
+export class InlineRegistryFixture {
+    @Get()
+    public list(): { items: string[] } {
+        return { items: [] };
+    }
+}

--- a/packages/metadata/test/unit/generator/generate-metadata.spec.ts
+++ b/packages/metadata/test/unit/generator/generate-metadata.spec.ts
@@ -17,6 +17,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generateMetadata } from '../../../src';
 import { ConfigErrorCode } from '../../../src/core/error/config-codes';
+import type { Preset, Registry } from '../../../src/adapters/decorator';
+import { createRegistry } from '../../../src/adapters/decorator';
 
 const entryPoint = [{
     cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..'),
@@ -46,6 +48,79 @@ describe('generateMetadata', () => {
 
         expect(metadata).toHaveProperty('controllers');
         expect(metadata.controllers.length).toBeGreaterThan(0);
+    });
+
+    it('should accept an inline Preset object', async () => {
+        const inline: Preset = {
+            name: 'inline-fixture',
+            extends: ['@trapi/preset-decorators-express'],
+        };
+        const metadata = await generateMetadata({
+            entryPoint,
+            cache: false,
+            preset: inline,
+        });
+
+        expect(metadata.controllers.length).toBeGreaterThan(0);
+    });
+
+    it('should accept an inline Registry without any preset', async () => {
+        // Minimal registry that only knows @Controller + @Get. We point at a
+        // dedicated fixture with no parameter decorators so body-inference
+        // doesn't conflict with the bare-bones registry.
+        const registry: Registry = createRegistry({
+            controllers: [{
+                match: { name: 'Controller', on: 'class' },
+                apply: (ctx, draft) => {
+                    const arg = ctx.argument(0);
+                    draft.paths = arg && arg.kind === 'literal' && typeof arg.raw === 'string' ?
+                        [arg.raw] :
+                        [''];
+                },
+            }],
+            methods: [{
+                match: { name: 'Get', on: 'method' },
+                apply: (_ctx, draft) => { draft.verb = 'get'; },
+            }],
+        });
+
+        const metadata = await generateMetadata({
+            entryPoint: [{
+                cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../data/inline-registry'),
+                pattern: '**/*.ts',
+            }],
+            cache: false,
+            registry,
+        });
+
+        expect(metadata.controllers.length).toBe(1);
+        expect(metadata.controllers[0].paths).toEqual(['widgets']);
+        expect(metadata.controllers[0].methods.length).toBe(1);
+        expect(metadata.controllers[0].methods[0].method).toBe('get');
+    });
+
+    it('should merge an inline registry on top of a preset (registry wins on scalar fields)', async () => {
+        // Inline parameter handler that overrides @Path to set a marker
+        // description so we can detect that it ran after the preset's handler.
+        const registry: Registry = createRegistry({
+            parameters: [{
+                match: { name: 'Path', on: 'parameter' },
+                apply: (_ctx, draft) => { draft.description = 'inline-override'; },
+            }],
+        });
+
+        const metadata = await generateMetadata({
+            entryPoint,
+            cache: false,
+            preset: '@trapi/preset-decorators-express',
+            registry,
+        });
+
+        const overridden = metadata.controllers
+            .flatMap((c) => c.methods)
+            .flatMap((m) => m.parameters)
+            .filter((p) => p.description === 'inline-override');
+        expect(overridden.length).toBeGreaterThan(0);
     });
 
     it('should throw when preset is omitted but source files contain decorators', async () => {


### PR DESCRIPTION
…neratorOptions

Widen `preset?: string` to `preset?: string | Preset` so an already-built Preset can be passed directly (still walked through `loadRegistry` so its `extends` chain resolves), and add `registry?: Registry` for fully manual handler wiring without authoring a Preset. When both are provided they merge: the preset-resolved registry runs first, the inline `registry` is appended after — inline handlers therefore win on scalar mutations and additively contribute on `append`-style fields.

Also extend `createRegistry()` to accept a `Partial<Registry>` seed so callers can write `createRegistry({ controllers: [...], methods: [...] })` instead of pushing post hoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Presets can now be configured as inline objects or string identifiers for greater flexibility
  * Registry handlers can be provided directly independent of preset configuration
  * Enhanced cache invalidation now accounts for preset configuration changes

* **Documentation**
  * Added comprehensive guide on configuring decorator handler options and precedence rules

* **Chores**
  * Updated contribution guidelines regarding commit message formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->