### PR TITLE
fix(swagger): cascade controller security to operations without their own

### DIFF
--- a/packages/swagger/src/adapters/generator/v2/module.ts
+++ b/packages/swagger/src/adapters/generator/v2/module.ts
@@ -203,7 +203,11 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
                 method.consumes = unique([...controller.consumes, ...method.consumes]);
                 method.produces = unique([...controller.produces, ...method.produces]);
                 method.tags = unique([...controller.tags, ...method.tags]);
-                method.security = method.security || controller.security;
+                // Inherit controller security only when the method declared none of its own.
+                // `[]` is truthy, so a plain `||` short-circuits and never cascades.
+                if (!method.security?.length) {
+                    method.security = controller.security;
+                }
                 // OpenAPI has no controller-level `deprecated` — cascade
                 // controller deprecation to every emitted operation.
                 method.deprecated = method.deprecated || controller.deprecated;
@@ -244,7 +248,7 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
 
         if (method.deprecated) { output.deprecated = method.deprecated; }
         if (method.tags.length) { output.tags = method.tags; }
-        if (method.security) {
+        if (method.security?.length) {
             output.security = method.security;
         }
 
@@ -587,7 +591,6 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
             consumes: method.consumes || [],
             produces: method.produces || [],
             responses: {},
-            security: method.security || [],
         };
 
         const produces : string[] = [];

--- a/packages/swagger/src/adapters/generator/v3/module.ts
+++ b/packages/swagger/src/adapters/generator/v3/module.ts
@@ -184,6 +184,14 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                 // controller deprecation to every emitted operation.
                 method.deprecated = method.deprecated || controller.deprecated;
 
+                // Inherit controller security only when the method declared none of its own.
+                // OpenAPI 3.x: an operation's `security: []` explicitly removes any inherited
+                // requirement, so we must omit the field when the method has no security
+                // rather than emitting an empty array.
+                if (!method.security?.length) {
+                    method.security = controller.security;
+                }
+
                 for (const controllerPath of controllerPaths) {
                     let path = removeFinalCharacter(
                         removeDuplicateSlashes(`/${controllerPath}/${method.path}`),
@@ -223,7 +231,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
             output.deprecated = method.deprecated;
         }
 
-        if (method.security) {
+        if (method.security?.length) {
             output.security = method.security as any[];
         }
 
@@ -420,7 +428,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
         if (method.description) {
             operation.description = method.description;
         }
-        if (method.security) {
+        if (method.security?.length) {
             operation.security = method.security;
         }
         if (method.deprecated) {

--- a/packages/swagger/test/unit/specification/security-cascade.spec.ts
+++ b/packages/swagger/test/unit/specification/security-cascade.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { SecurityDefinitions, SpecV2, SpecV3 } from '../../../src';
+import { Version, generateSwagger } from '../../../src';
+import {
+    createController,
+    createMetadata,
+    createMethod,
+    createResponse,
+} from '../../helpers/metadata-builder';
+
+describe('controller -> method security cascade (#832)', () => {
+    const securityDefinitions: SecurityDefinitions = { bearerAuth: { type: 'http', scheme: 'basic' } };
+
+    describe('controller has security, method has none', () => {
+        let specV2: SpecV2;
+        let specV3: SpecV3;
+
+        beforeAll(async () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'SecureController',
+                    paths: ['secure'],
+                    security: [{ bearerAuth: [] }],
+                    methods: [
+                        createMethod({
+                            name: 'inheritEndpoint',
+                            method: 'get',
+                            path: 'inherit',
+                            security: [],
+                            responses: [createResponse({ status: '200', description: 'Ok' })],
+                        }),
+                    ],
+                }),
+            ]);
+
+            specV2 = await generateSwagger({
+                version: Version.V2,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+
+            specV3 = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+        });
+
+        it('V2 should cascade controller security onto the operation', () => {
+            const op = specV2.paths['/secure/inherit'].get!;
+            expect(op.security).toEqual([{ bearerAuth: [] }]);
+        });
+
+        it('V3 should cascade controller security onto the operation', () => {
+            const op = specV3.paths['/secure/inherit'].get!;
+            expect(op.security).toEqual([{ bearerAuth: [] }]);
+        });
+    });
+
+    describe('method has its own security', () => {
+        let specV2: SpecV2;
+        let specV3: SpecV3;
+
+        beforeAll(async () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'SecureController',
+                    paths: ['secure'],
+                    security: [{ bearerAuth: [] }],
+                    methods: [
+                        createMethod({
+                            name: 'overrideEndpoint',
+                            method: 'get',
+                            path: 'override',
+                            security: [{ apiKey: [] }],
+                            responses: [createResponse({ status: '200', description: 'Ok' })],
+                        }),
+                    ],
+                }),
+            ]);
+
+            specV2 = await generateSwagger({
+                version: Version.V2,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+
+            specV3 = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+        });
+
+        it('V2 should use the method security and ignore controller security', () => {
+            const op = specV2.paths['/secure/override'].get!;
+            expect(op.security).toEqual([{ apiKey: [] }]);
+        });
+
+        it('V3 should use the method security and ignore controller security', () => {
+            const op = specV3.paths['/secure/override'].get!;
+            expect(op.security).toEqual([{ apiKey: [] }]);
+        });
+    });
+
+    describe('neither controller nor method has security', () => {
+        let specV2: SpecV2;
+        let specV3: SpecV3;
+
+        beforeAll(async () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'OpenController',
+                    paths: ['open'],
+                    security: [],
+                    methods: [
+                        createMethod({
+                            name: 'openEndpoint',
+                            method: 'get',
+                            path: 'endpoint',
+                            security: [],
+                            responses: [createResponse({ status: '200', description: 'Ok' })],
+                        }),
+                    ],
+                }),
+            ]);
+
+            specV2 = await generateSwagger({
+                version: Version.V2,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+
+            specV3 = await generateSwagger({
+                version: Version.V3,
+                metadata,
+                data: { servers: 'http://localhost:3000/', securityDefinitions },
+            });
+        });
+
+        // Per OpenAPI 3.x: an operation `security: []` explicitly removes any inherited
+        // requirement. We must omit the field entirely when no requirement is intended,
+        // not emit an empty array.
+        it('V2 should omit operation security', () => {
+            const op = specV2.paths['/open/endpoint'].get!;
+            expect(op.security).toBeUndefined();
+        });
+
+        it('V3 should omit operation security', () => {
+            const op = specV3.paths['/open/endpoint'].get!;
+            expect(op.security).toBeUndefined();
+        });
+    });
+});

--- a/packages/swagger/test/unit/specification/security-cascade.spec.ts
+++ b/packages/swagger/test/unit/specification/security-cascade.spec.ts
@@ -21,7 +21,14 @@ import {
 } from '../../helpers/metadata-builder';
 
 describe('controller -> method security cascade (#832)', () => {
-    const securityDefinitions: SecurityDefinitions = { bearerAuth: { type: 'http', scheme: 'basic' } };
+    const securityDefinitions: SecurityDefinitions = {
+        bearerAuth: { type: 'http', scheme: 'basic' },
+        apiKey: {
+            type: 'apiKey', 
+            name: 'X-API-Key', 
+            in: 'header', 
+        },
+    };
 
     describe('controller has security, method has none', () => {
         let specV2: SpecV2;


### PR DESCRIPTION
## Summary

- V2 + V3 emitters check `method.security?.length` instead of truthiness, so an empty array no longer short-circuits the cascade.
- When the method has no security of its own, both emitters inherit `controller.security` (V3 previously had no cascade at all).
- When neither has security, the operation-level `security` field is omitted — never `security: []`, which OpenAPI 3.x interprets as an explicit removal of any inherited requirement.
- V2's `buildOperation` no longer pre-fills `security: []`.

Closes #832.

## Test plan

- [x] New `packages/swagger/test/unit/specification/security-cascade.spec.ts` covers cascade / override / neither for both V2 and V3.
- [x] Full `nx run-many -t test` (212 swagger tests, all packages green).
- [x] `npm run lint` clean.
- [x] `nx run-many -t build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security inheritance behavior in OpenAPI specification generation. Method-level security settings now properly override controller-level settings, and explicitly empty security configurations are correctly respected across OpenAPI v2 and v3 specifications.

* **Tests**
  * Added comprehensive test coverage for security cascade scenarios across OpenAPI versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->