### PR TITLE
fix(swagger): emit "/" for root path instead of empty string

### DIFF
--- a/packages/swagger/src/adapters/generator/v2/module.ts
+++ b/packages/swagger/src/adapters/generator/v2/module.ts
@@ -28,7 +28,6 @@ import {
     isUndefinedType,
     isVoidType,
 } from '@trapi/core';
-import path from 'node:path';
 import { URL } from 'node:url';
 import { merge } from 'smob';
 
@@ -45,7 +44,7 @@ import type {
 import { DataTypeName, ParameterSourceV2 } from '../../../core/schema';
 import type { SecurityDefinitions } from '../../../core/types';
 import { SwaggerError, SwaggerErrorCode } from '../../../core/error';
-import { normalizePathParameters } from '../../../core/utils';
+import { joinPaths, normalizePathParameters } from '../../../core/utils';
 import { AbstractSpecGenerator } from '../abstract';
 
 function uniqueOperationId(base: string, used: Set<string>): string {
@@ -215,8 +214,7 @@ export class V2Generator extends AbstractSpecGenerator<SpecV2, SchemaV2> {
                 method.responses = unique([...controller.responses, ...method.responses]);
 
                 for (const controllerPath of controllerPaths) {
-                    let fullPath = path.posix.join('/', controllerPath, method.path);
-                    fullPath = normalizePathParameters(fullPath);
+                    const fullPath = normalizePathParameters(joinPaths(controllerPath, method.path));
 
                     const pathItem = output[fullPath] ?? (output[fullPath] = {});
                     pathItem[method.method] = this.buildMethod(method, fullPath, usedOperationIds);

--- a/packages/swagger/src/adapters/generator/v3/module.ts
+++ b/packages/swagger/src/adapters/generator/v3/module.ts
@@ -58,9 +58,8 @@ import type { SpecGeneratorOptionsInput } from '../../../core/config';
 import type { SecurityDefinitions } from '../../../core/types';
 import { SwaggerError, SwaggerErrorCode } from '../../../core/error';
 import {
+    joinPaths,
     normalizePathParameters,
-    removeDuplicateSlashes,
-    removeFinalCharacter,
 } from '../../../core/utils';
 import { AbstractSpecGenerator } from '../abstract';
 import type { Version } from '../../../core/constants';
@@ -193,11 +192,7 @@ export class V3Generator extends AbstractSpecGenerator<SpecV3, SchemaV3> {
                 }
 
                 for (const controllerPath of controllerPaths) {
-                    let path = removeFinalCharacter(
-                        removeDuplicateSlashes(`/${controllerPath}/${method.path}`),
-                        '/',
-                    );
-                    path = normalizePathParameters(path);
+                    const path = normalizePathParameters(joinPaths(controllerPath, method.path));
 
                     const pathItem = output[path] ?? (output[path] = {});
                     pathItem[method.method] = this.buildMethod(controller.name, method, path, usedOperationIds);

--- a/packages/swagger/src/core/utils/character.ts
+++ b/packages/swagger/src/core/utils/character.ts
@@ -6,7 +6,8 @@
  */
 
 export function removeDuplicateSlashes(str: string) : string {
-    return str.replace(/\/{2,}/g, '/');
+    // URL-safe: a `:/` boundary (e.g. `http://`) is not collapsed.
+    return str.replace(/([^:]\/)\/+/g, '$1');
 }
 
 export function removeFinalCharacter(

--- a/packages/swagger/src/core/utils/character.ts
+++ b/packages/swagger/src/core/utils/character.ts
@@ -6,7 +6,7 @@
  */
 
 export function removeDuplicateSlashes(str: string) : string {
-    return str.replace('/([^:]$)/+/g', '$1');
+    return str.replace(/\/{2,}/g, '/');
 }
 
 export function removeFinalCharacter(

--- a/packages/swagger/src/core/utils/path.ts
+++ b/packages/swagger/src/core/utils/path.ts
@@ -18,3 +18,18 @@ export function normalizePathParameters(str: string) : string {
 
     return str;
 }
+
+// OpenAPI 3.x §4.8.8 requires every `paths` key to start with `/`. Joining a
+// controller path with a method path naively (template literal + slash
+// stripping) collapses the root combination — `''` + `'/'`, `'/'` + `''`,
+// `'/'` + `'/'` — to an empty string, which strict validators reject.
+export function joinPaths(...segments: string[]): string {
+    let result = segments.join('/').replace(/\/{2,}/g, '/');
+    if (!result.startsWith('/')) {
+        result = `/${result}`;
+    }
+    if (result.length > 1 && result.endsWith('/')) {
+        result = result.slice(0, -1);
+    }
+    return result;
+}

--- a/packages/swagger/test/unit/specification/root-path.spec.ts
+++ b/packages/swagger/test/unit/specification/root-path.spec.ts
@@ -22,36 +22,36 @@ const servers = [{ url: '/' }];
 // validators reject (§4.8.8 requires every paths key to start with '/').
 describe('root path emission', () => {
     const cases: Array<{
-        controller: string; 
-        method: string; 
-        label: string 
+        controller: string;
+        method: string;
+        label: string
     }> = [
         {
-            controller: '', 
-            method: '/', 
-            label: "@Controller('') + @Get('/')", 
+            controller: '',
+            method: '/',
+            label: "@Controller('') + @Get('/')",
         },
         {
-            controller: '/', 
-            method: '', 
-            label: "@Controller('/') + @Get('')", 
+            controller: '/',
+            method: '',
+            label: "@Controller('/') + @Get('')",
         },
         {
-            controller: '/', 
-            method: '/', 
-            label: "@Controller('/') + @Get('/')", 
+            controller: '/',
+            method: '/',
+            label: "@Controller('/') + @Get('/')",
         },
         {
-            controller: '', 
-            method: '', 
-            label: "@Controller('') + @Get('')", 
+            controller: '',
+            method: '',
+            label: "@Controller('') + @Get('')",
         },
     ];
 
     for (const {
-        controller, 
-        method, 
-        label, 
+        controller,
+        method,
+        label,
     } of cases) {
         describe(label, () => {
             const metadata = createMetadata([
@@ -106,16 +106,16 @@ describe('root path emission', () => {
         ]);
 
         const v3 = await generateSwagger({
-            version: Version.V3, 
-            metadata, 
-            data: { servers }, 
+            version: Version.V3,
+            metadata,
+            data: { servers },
         });
         expect(Object.keys(v3.paths)).toEqual(['/events']);
 
         const v2 = await generateSwagger({
-            version: Version.V2, 
-            metadata, 
-            data: { servers }, 
+            version: Version.V2,
+            metadata,
+            data: { servers },
         });
         expect(Object.keys(v2.paths)).toEqual(['/events']);
     });

--- a/packages/swagger/test/unit/specification/root-path.spec.ts
+++ b/packages/swagger/test/unit/specification/root-path.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Version, generateSwagger } from '../../../src';
+import {
+    createController,
+    createMetadata,
+    createMethod,
+    createResponse,
+} from '../../helpers/metadata-builder';
+
+const servers = [{ url: '/' }];
+
+// Regression test for issue #835: root-route combinations
+// (controller='' + method='/', controller='/' + method='', controller='/'
+// + method='/') previously emitted '' as a paths key, which strict OpenAPI
+// validators reject (§4.8.8 requires every paths key to start with '/').
+describe('root path emission', () => {
+    const cases: Array<{
+        controller: string; 
+        method: string; 
+        label: string 
+    }> = [
+        {
+            controller: '', 
+            method: '/', 
+            label: "@Controller('') + @Get('/')", 
+        },
+        {
+            controller: '/', 
+            method: '', 
+            label: "@Controller('/') + @Get('')", 
+        },
+        {
+            controller: '/', 
+            method: '/', 
+            label: "@Controller('/') + @Get('/')", 
+        },
+        {
+            controller: '', 
+            method: '', 
+            label: "@Controller('') + @Get('')", 
+        },
+    ];
+
+    for (const {
+        controller, 
+        method, 
+        label, 
+    } of cases) {
+        describe(label, () => {
+            const metadata = createMetadata([
+                createController({
+                    name: 'RootController',
+                    paths: [controller],
+                    methods: [
+                        createMethod({
+                            name: 'status',
+                            method: 'get',
+                            path: method,
+                            responses: [createResponse({ status: '200' })],
+                        }),
+                    ],
+                }),
+            ]);
+
+            it('emits "/" for v3', async () => {
+                const spec = await generateSwagger({
+                    version: Version.V3,
+                    metadata,
+                    data: { servers },
+                });
+                expect(Object.keys(spec.paths)).toEqual(['/']);
+            });
+
+            it('emits "/" for v2', async () => {
+                const spec = await generateSwagger({
+                    version: Version.V2,
+                    metadata,
+                    data: { servers },
+                });
+                expect(Object.keys(spec.paths)).toEqual(['/']);
+            });
+        });
+    }
+
+    it('does not collapse non-root paths to "/"', async () => {
+        const metadata = createMetadata([
+            createController({
+                name: 'EventsController',
+                paths: ['/events'],
+                methods: [
+                    createMethod({
+                        name: 'list',
+                        method: 'get',
+                        path: '/',
+                        responses: [createResponse({ status: '200' })],
+                    }),
+                ],
+            }),
+        ]);
+
+        const v3 = await generateSwagger({
+            version: Version.V3, 
+            metadata, 
+            data: { servers }, 
+        });
+        expect(Object.keys(v3.paths)).toEqual(['/events']);
+
+        const v2 = await generateSwagger({
+            version: Version.V2, 
+            metadata, 
+            data: { servers }, 
+        });
+        expect(Object.keys(v2.paths)).toEqual(['/events']);
+    });
+
+    it('keeps root and non-root operations separate in the same document', async () => {
+        const metadata = createMetadata([
+            createController({
+                name: 'RootController',
+                paths: [''],
+                methods: [
+                    createMethod({
+                        name: 'status',
+                        method: 'get',
+                        path: '/',
+                        responses: [createResponse({ status: '200' })],
+                    }),
+                ],
+            }),
+            createController({
+                name: 'EventsController',
+                paths: ['/events'],
+                methods: [
+                    createMethod({
+                        name: 'list',
+                        method: 'get',
+                        path: '',
+                        responses: [createResponse({ status: '200' })],
+                    }),
+                ],
+            }),
+        ]);
+
+        const spec = await generateSwagger({
+            version: Version.V3,
+            metadata,
+            data: { servers },
+        });
+        expect(Object.keys(spec.paths).sort()).toEqual(['/', '/events']);
+    });
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,7 +24,8 @@
             "components": [
                 "core",
                 "metadata",
-                "swagger"
+                "swagger",
+                "cli"
             ]
         }
     ],


### PR DESCRIPTION
## Summary

- The V3 emitter collapsed every root-route combination — `@Controller('') + @Get('/')`, `@Controller('/') + @Get('')`, `@Controller('/') + @Get('/')` — to an empty `paths` key, which strict OpenAPI validators reject (§4.8.8 requires every `paths` key to start with `/`).
- Replaces the ad-hoc concatenation in both V2 and V3 with a shared `joinPaths` helper that collapses duplicate slashes, ensures a leading `/`, and only strips a trailing `/` when the result is longer than `/`.
- Fixes a latent bug in `removeDuplicateSlashes` whose pattern was a string literal rather than a regex — it never actually replaced anything.

Closes #835

## Test plan

- [x] New `packages/swagger/test/unit/specification/root-path.spec.ts` covers all four root-route combinations from the issue under V2 + V3, plus regressions for non-root paths and a mixed root/non-root document.
- [x] `npx nx run-many -t test` — all 5 packages green (222 swagger tests, 229 metadata tests).
- [x] `npm run lint` clean.
- [x] `npx nx run @trapi/swagger:build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed root path generation in OpenAPI v2 and v3 specifications to correctly emit root paths when applicable
* **Tests**
  * Added comprehensive regression test suite covering root and non-root path generation scenarios in OpenAPI specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->