### PR TITLE
fix(deps): bump locter to v4 beta and migrate to the read/write API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coveralls.yml
 tsconfig.tsbuildinfo
 .nx
 .claude/settings.local.json
+.claude/worktrees/
 .claude/scheduled_tasks.lock
 .agents/plans
 packages/docs/src/.vitepress/cache

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ export default [
             '**/dist/**',
             '**/bin/**',
             'packages/docs/**',
+            '.claude/**',
         ],
     },
     ...await config(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5883,9 +5883,9 @@
             }
         },
         "node_modules/locter": {
-            "version": "4.0.0-beta.0",
-            "resolved": "https://registry.npmjs.org/locter/-/locter-4.0.0-beta.0.tgz",
-            "integrity": "sha512-loRvXHHZpwzdLc0cOMhPeMCDnH378qj0tpzlyeh+NcQNdh//e9UOHxj1dGcVV0Lrv9iSqVfhQppADWp83oRbnw==",
+            "version": "4.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/locter/-/locter-4.0.0-beta.1.tgz",
+            "integrity": "sha512-93qffypjudiOHldTuaNU8+r+cvkGrDL8x3qq8fRIhcZf4XF1KVYGEuSMdFv94Dha5JvzPAUDOLP7Sd+U4nXLWQ==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.1.0",
@@ -8858,7 +8858,7 @@
                 "@trapi/swagger": "^2.0.1",
                 "chokidar": "^5.0.0",
                 "citty": "^0.2.2",
-                "locter": "^4.0.0-beta.0",
+                "locter": "^4.0.0-beta.1",
                 "smob": "^1.6.2"
             },
             "bin": {
@@ -8875,7 +8875,7 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@validup/adapter-zod": "^0.2.4",
-                "locter": "^4.0.0-beta.0",
+                "locter": "^4.0.0-beta.1",
                 "smob": "^1.6.2",
                 "validup": "^0.5.0",
                 "zod": "^4.4.3"
@@ -8911,7 +8911,7 @@
                 "@ebec/core": "^1.1.0",
                 "@trapi/core": "2.0.1",
                 "flatted": "^3.3.3",
-                "locter": "^4.0.0-beta.0",
+                "locter": "^4.0.0-beta.1",
                 "minimatch": "^10.0.3",
                 "smob": "^1.6.2"
             },
@@ -8951,6 +8951,7 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@trapi/core": "2.0.1",
+                "locter": "^4.0.0-beta.1",
                 "smob": "^1.6.2",
                 "yamljs": "^0.3.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5883,9 +5883,9 @@
             }
         },
         "node_modules/locter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locter/-/locter-3.0.0.tgz",
-            "integrity": "sha512-crC8Usl4KmSi/sMaKU1pbo/NcfgbMPv9KIS86zxKguFaKhDP21m/l8nsMsopEtYIvXwa/v8FRtBPQd/z1AiFdQ==",
+            "version": "4.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/locter/-/locter-4.0.0-beta.0.tgz",
+            "integrity": "sha512-loRvXHHZpwzdLc0cOMhPeMCDnH378qj0tpzlyeh+NcQNdh//e9UOHxj1dGcVV0Lrv9iSqVfhQppADWp83oRbnw==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.1.0",
@@ -8858,7 +8858,8 @@
                 "@trapi/swagger": "^2.0.1",
                 "chokidar": "^5.0.0",
                 "citty": "^0.2.2",
-                "locter": "^3.0.0"
+                "locter": "^4.0.0-beta.0",
+                "smob": "^1.6.2"
             },
             "bin": {
                 "trapi": "dist/bin.mjs"
@@ -8874,7 +8875,8 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@validup/adapter-zod": "^0.2.4",
-                "locter": "^3.0.0",
+                "locter": "^4.0.0-beta.0",
+                "smob": "^1.6.2",
                 "validup": "^0.5.0",
                 "zod": "^4.4.3"
             }
@@ -8909,8 +8911,9 @@
                 "@ebec/core": "^1.1.0",
                 "@trapi/core": "2.0.1",
                 "flatted": "^3.3.3",
-                "locter": "^3.0.0",
-                "minimatch": "^10.0.3"
+                "locter": "^4.0.0-beta.0",
+                "minimatch": "^10.0.3",
+                "smob": "^1.6.2"
             },
             "devDependencies": {
                 "jsonata": "^2.2.1"
@@ -8954,7 +8957,7 @@
             "devDependencies": {
                 "@types/yamljs": "^0.2.34",
                 "jsonata": "^2.2.1",
-                "locter": "^3.0.0"
+                "locter": "^4.0.0-beta.0"
             },
             "engines": {
                 "node": ">=22.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,13 +2280,6 @@
             "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
             "license": "MIT"
         },
-        "node_modules/@types/yamljs": {
-            "version": "0.2.34",
-            "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.34.tgz",
-            "integrity": "sha512-gJvfRlv9ErxdOv7ux7UsJVePtX54NAvQyd8ncoiFqK8G5aeHIfQfGH2fbruvjAQ9657HwAaO54waS+Dsk2QTUQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.60.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
@@ -3697,12 +3690,6 @@
                 "dot-prop": "^5.1.0"
             }
         },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "license": "MIT"
-        },
         "node_modules/conventional-changelog-angular": {
             "version": "8.3.1",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -4800,12 +4787,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4913,27 +4894,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4945,34 +4905,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/global-directory": {
@@ -5254,21 +5186,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -5883,9 +5805,9 @@
             }
         },
         "node_modules/locter": {
-            "version": "4.0.0-beta.1",
-            "resolved": "https://registry.npmjs.org/locter/-/locter-4.0.0-beta.1.tgz",
-            "integrity": "sha512-93qffypjudiOHldTuaNU8+r+cvkGrDL8x3qq8fRIhcZf4XF1KVYGEuSMdFv94Dha5JvzPAUDOLP7Sd+U4nXLWQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/locter/-/locter-4.0.0.tgz",
+            "integrity": "sha512-lzXhimreu7jX7JzlnXqQOqYspdxbP/9iv5QalzW0GA2uBQD//p8lDRDQzMsReJ6UjJk08iYzyTuI3GgauWD49Q==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.1.0",
@@ -6466,6 +6388,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -6646,15 +6569,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -7341,12 +7255,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "license": "BSD-3-Clause"
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -8728,6 +8636,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/xml-name-validator": {
@@ -8763,29 +8672,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/eemeli"
-            }
-        },
-        "node_modules/yamljs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-            "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "glob": "^7.0.5"
-            },
-            "bin": {
-                "json2yaml": "bin/json2yaml",
-                "yaml2json": "bin/yaml2json"
-            }
-        },
-        "node_modules/yamljs/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/yargs": {
@@ -8858,7 +8744,7 @@
                 "@trapi/swagger": "^2.0.1",
                 "chokidar": "^5.0.0",
                 "citty": "^0.2.2",
-                "locter": "^4.0.0-beta.1",
+                "locter": "^4.0.0",
                 "smob": "^1.6.2"
             },
             "bin": {
@@ -8875,7 +8761,7 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@validup/adapter-zod": "^0.2.4",
-                "locter": "^4.0.0-beta.1",
+                "locter": "^4.0.0",
                 "smob": "^1.6.2",
                 "validup": "^0.5.0",
                 "zod": "^4.4.3"
@@ -8911,7 +8797,7 @@
                 "@ebec/core": "^1.1.0",
                 "@trapi/core": "2.0.1",
                 "flatted": "^3.3.3",
-                "locter": "^4.0.0-beta.1",
+                "locter": "^4.0.0",
                 "minimatch": "^10.0.3",
                 "smob": "^1.6.2"
             },
@@ -8951,14 +8837,11 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@trapi/core": "2.0.1",
-                "locter": "^4.0.0-beta.1",
-                "smob": "^1.6.2",
-                "yamljs": "^0.3.0"
+                "locter": "^4.0.0",
+                "smob": "^1.6.2"
             },
             "devDependencies": {
-                "@types/yamljs": "^0.2.34",
-                "jsonata": "^2.2.1",
-                "locter": "^4.0.0-beta.0"
+                "jsonata": "^2.2.1"
             },
             "engines": {
                 "node": ">=22.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
         "@trapi/swagger": "^2.0.1",
         "chokidar": "^5.0.0",
         "citty": "^0.2.2",
-        "locter": "^4.0.0-beta.0",
+        "locter": "^4.0.0-beta.1",
         "smob": "^1.6.2"
     },
     "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
         "@trapi/swagger": "^2.0.1",
         "chokidar": "^5.0.0",
         "citty": "^0.2.2",
-        "locter": "^4.0.0-beta.1",
+        "locter": "^4.0.0",
         "smob": "^1.6.2"
     },
     "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,8 @@
         "@trapi/swagger": "^2.0.1",
         "chokidar": "^5.0.0",
         "citty": "^0.2.2",
-        "locter": "^3.0.0"
+        "locter": "^4.0.0-beta.0",
+        "smob": "^1.6.2"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/packages/cli/src/config/load.ts
+++ b/packages/cli/src/config/load.ts
@@ -9,10 +9,10 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import {
     buildFilePath,
-    isObject,
-    load,
     locate,
+    read,
 } from 'locter';
+import { isObject } from 'smob';
 import { CLIUserError } from '../logger.ts';
 import type { LoadedConfig, TrapiConfigEntry } from './types.ts';
 
@@ -59,7 +59,7 @@ export async function loadConfig(options: LoadConfigOptions): Promise<LoadedConf
 async function readConfigFile(filePath: string): Promise<LoadedConfig> {
     let mod: unknown;
     try {
-        mod = await load(filePath);
+        mod = await read(filePath);
     } catch (err) {
         throw new CLIUserError(
             `Failed to load config "${filePath}": ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,8 @@
     "dependencies": {
         "@ebec/core": "^1.1.0",
         "@validup/adapter-zod": "^0.2.4",
-        "locter": "^3.0.0",
+        "locter": "^4.0.0-beta.0",
+        "smob": "^1.6.2",
         "validup": "^0.5.0",
         "zod": "^4.4.3"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@ebec/core": "^1.1.0",
         "@validup/adapter-zod": "^0.2.4",
-        "locter": "^4.0.0-beta.1",
+        "locter": "^4.0.0",
         "smob": "^1.6.2",
         "validup": "^0.5.0",
         "zod": "^4.4.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@ebec/core": "^1.1.0",
         "@validup/adapter-zod": "^0.2.4",
-        "locter": "^4.0.0-beta.0",
+        "locter": "^4.0.0-beta.1",
         "smob": "^1.6.2",
         "validup": "^0.5.0",
         "zod": "^4.4.3"

--- a/packages/core/src/decorator/module.ts
+++ b/packages/core/src/decorator/module.ts
@@ -6,6 +6,7 @@
  */
 
 import { LocterNotFoundError, readAsModule } from 'locter';
+import { isObject } from 'smob';
 import type {
     AnyDecoratorHandler,
     AnyJsDocHandler,
@@ -287,10 +288,10 @@ function isModuleNotFoundError(error: unknown): boolean {
     }
     // Fallback for errors raised outside locter's readAsModule() (e.g. custom
     // resolvers re-throwing Node module errors).
-    if (typeof error !== 'object' || error === null) {
+    if (!isObject(error)) {
         return false;
     }
-    const { code } = (error as { code?: unknown });
+    const { code } = error;
     return typeof code === 'string' && MODULE_NOT_FOUND_CODES.has(code);
 }
 

--- a/packages/core/src/decorator/module.ts
+++ b/packages/core/src/decorator/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { LocterNotFoundError, read } from 'locter';
+import { LocterNotFoundError, readAsModule } from 'locter';
 import type {
     AnyDecoratorHandler,
     AnyJsDocHandler,
@@ -239,7 +239,7 @@ export async function resolvePresetByName(input: string): Promise<Preset> {
 
     for (const lookupPath of lookupPaths) {
         try {
-            const moduleExport = await read(lookupPath) as Record<string, unknown>;
+            const moduleExport = await readAsModule(lookupPath) as Record<string, unknown>;
 
             const candidates: unknown[] = [
                 (moduleExport as { preset?: unknown }).preset,
@@ -285,7 +285,7 @@ function isModuleNotFoundError(error: unknown): boolean {
     if (error instanceof LocterNotFoundError) {
         return true;
     }
-    // Fallback for errors raised outside locter's read() (e.g. custom
+    // Fallback for errors raised outside locter's readAsModule() (e.g. custom
     // resolvers re-throwing Node module errors).
     if (typeof error !== 'object' || error === null) {
         return false;

--- a/packages/core/src/decorator/module.ts
+++ b/packages/core/src/decorator/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { LocterNotFoundError, load } from 'locter';
+import { LocterNotFoundError, read } from 'locter';
 import type {
     AnyDecoratorHandler,
     AnyJsDocHandler,
@@ -239,7 +239,7 @@ export async function resolvePresetByName(input: string): Promise<Preset> {
 
     for (const lookupPath of lookupPaths) {
         try {
-            const moduleExport = await load(lookupPath) as Record<string, unknown>;
+            const moduleExport = await read(lookupPath) as Record<string, unknown>;
 
             const candidates: unknown[] = [
                 (moduleExport as { preset?: unknown }).preset,
@@ -285,7 +285,7 @@ function isModuleNotFoundError(error: unknown): boolean {
     if (error instanceof LocterNotFoundError) {
         return true;
     }
-    // Fallback for errors raised outside locter's load() (e.g. custom
+    // Fallback for errors raised outside locter's read() (e.g. custom
     // resolvers re-throwing Node module errors).
     if (typeof error !== 'object' || error === null) {
         return false;

--- a/packages/core/src/metadata/type-guards.ts
+++ b/packages/core/src/metadata/type-guards.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { hasOwnProperty, isObject } from 'locter';
+import { hasOwnProperty, isObject } from 'smob';
 import type { Metadata } from './types';
 
 export function isMetadata(input: unknown): input is Metadata {

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -55,7 +55,7 @@
         "@ebec/core": "^1.1.0",
         "@trapi/core": "2.0.1",
         "flatted": "^3.3.3",
-        "locter": "^4.0.0-beta.1",
+        "locter": "^4.0.0",
         "minimatch": "^10.0.3",
         "smob": "^1.6.2"
     },

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -55,7 +55,7 @@
         "@ebec/core": "^1.1.0",
         "@trapi/core": "2.0.1",
         "flatted": "^3.3.3",
-        "locter": "^4.0.0-beta.0",
+        "locter": "^4.0.0-beta.1",
         "minimatch": "^10.0.3",
         "smob": "^1.6.2"
     },

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -55,8 +55,9 @@
         "@ebec/core": "^1.1.0",
         "@trapi/core": "2.0.1",
         "flatted": "^3.3.3",
-        "locter": "^3.0.0",
-        "minimatch": "^10.0.3"
+        "locter": "^4.0.0-beta.0",
+        "minimatch": "^10.0.3",
+        "smob": "^1.6.2"
     },
     "peerDependencies": {
         "typescript": ">=5.0.0"

--- a/packages/metadata/src/adapters/decorator/module.ts
+++ b/packages/metadata/src/adapters/decorator/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { read } from 'locter';
+import { readAsModule } from 'locter';
 import type {
     AnyDecoratorHandler,
     AnyJsDocHandler,
@@ -219,7 +219,7 @@ export async function resolvePresetByName(input: string): Promise<Preset> {
 
     for (const lookupPath of lookupPaths) {
         try {
-            const moduleExport = await read(lookupPath) as Record<string, unknown>;
+            const moduleExport = await readAsModule(lookupPath) as Record<string, unknown>;
 
             const candidates: unknown[] = [
                 (moduleExport as { preset?: unknown }).preset,

--- a/packages/metadata/src/adapters/decorator/module.ts
+++ b/packages/metadata/src/adapters/decorator/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { load } from 'locter';
+import { read } from 'locter';
 import type {
     AnyDecoratorHandler,
     AnyJsDocHandler,
@@ -219,7 +219,7 @@ export async function resolvePresetByName(input: string): Promise<Preset> {
 
     for (const lookupPath of lookupPaths) {
         try {
-            const moduleExport = await load(lookupPath) as Record<string, unknown>;
+            const moduleExport = await read(lookupPath) as Record<string, unknown>;
 
             const candidates: unknown[] = [
                 (moduleExport as { preset?: unknown }).preset,

--- a/packages/metadata/src/adapters/filesystem/tsconfig/module.ts
+++ b/packages/metadata/src/adapters/filesystem/tsconfig/module.ts
@@ -34,9 +34,9 @@ export async function loadTSConfig(
         filePath = path.join(cwd, fileName);
     }
 
-    // read() returns a frozen module record; unwrap to the mutable
-    // parsed value (compilerOptions is reassigned below)
-    const content = (await read(filePath)).default;
+    // read() returns the raw parsed value for data formats —
+    // mutable, so compilerOptions can be reassigned below
+    const content = await read(filePath);
     if (!isObject(content)) {
         throw new ConfigError({
             message: `The tsconfig file '${filePath}' is malformed.`,

--- a/packages/metadata/src/adapters/filesystem/tsconfig/module.ts
+++ b/packages/metadata/src/adapters/filesystem/tsconfig/module.ts
@@ -5,7 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject, load } from 'locter';
+import { read } from 'locter';
+import { isObject } from 'smob';
 import { ConfigErrorCode } from '../../../core/error/config-codes';
 import { ConfigError } from '../../../core/error/config';
 import process from 'node:process';
@@ -33,7 +34,9 @@ export async function loadTSConfig(
         filePath = path.join(cwd, fileName);
     }
 
-    const content = await load(filePath);
+    // read() returns a frozen module record; unwrap to the mutable
+    // parsed value (compilerOptions is reassigned below)
+    const content = (await read(filePath)).default;
     if (!isObject(content)) {
         throw new ConfigError({
             message: `The tsconfig file '${filePath}' is malformed.`,

--- a/packages/metadata/src/adapters/typescript/js-doc/utils.ts
+++ b/packages/metadata/src/adapters/typescript/js-doc/utils.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject } from 'locter';
+import { isObject } from 'smob';
 import type { JSDocComment, NodeArray } from 'typescript';
 
 export function transformJSDocComment(

--- a/packages/metadata/src/app/generator/parameter/module.ts
+++ b/packages/metadata/src/app/generator/parameter/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject } from 'locter';
+import { isObject } from 'smob';
 import { NodeBuilderFlags, displayPartsToString, isIdentifier } from 'typescript';
 import type { ParameterDeclaration } from 'typescript';
 import {

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -50,7 +50,8 @@
         "@ebec/core": "^1.1.0",
         "@trapi/core": "2.0.1",
         "smob": "^1.6.2",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "locter": "^4.0.0-beta.1"
     },
     "repository": {
         "type": "git",

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -42,16 +42,13 @@
         "preblushOnly": "npm run build"
     },
     "devDependencies": {
-        "@types/yamljs": "^0.2.34",
-        "jsonata": "^2.2.1",
-        "locter": "^4.0.0-beta.0"
+        "jsonata": "^2.2.1"
     },
     "dependencies": {
         "@ebec/core": "^1.1.0",
         "@trapi/core": "2.0.1",
         "smob": "^1.6.2",
-        "yamljs": "^0.3.0",
-        "locter": "^4.0.0-beta.1"
+        "locter": "^4.0.0"
     },
     "repository": {
         "type": "git",

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@types/yamljs": "^0.2.34",
         "jsonata": "^2.2.1",
-        "locter": "^3.0.0"
+        "locter": "^4.0.0-beta.0"
     },
     "dependencies": {
         "@ebec/core": "^1.1.0",

--- a/packages/swagger/src/app/save.ts
+++ b/packages/swagger/src/app/save.ts
@@ -8,7 +8,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import process from 'node:process';
-import YAML from 'yamljs';
+import { YAMLWriter } from 'locter';
 import type { SwaggerSaveOptions } from '../core/config';
 import { DocumentFormat } from '../core/constants';
 import type { SpecV2, SpecV3 } from '../core/schema';
@@ -23,7 +23,7 @@ function resolveFileName(name: string | undefined, format: `${DocumentFormat}`):
 
 function serialise(spec: SpecV2 | SpecV3, format: `${DocumentFormat}`): string {
     if (format === DocumentFormat.YAML) {
-        return YAML.stringify(spec, 1000);
+        return new YAMLWriter().stringify(spec);
     }
     return JSON.stringify(spec, null, 4);
 }

--- a/packages/swagger/test/unit/specification/abstract-entity-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/abstract-entity-endpoint.spec.ts
@@ -21,7 +21,7 @@ describe('AbstractEntityEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/abstract-entity-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/abstract-entity-endpoint.spec.ts
@@ -11,7 +11,7 @@ import {
     expect, 
     it, 
 } from 'vitest';
-import { load } from 'locter';
+import { read } from 'locter';
 import jsonata from 'jsonata';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
@@ -21,7 +21,7 @@ describe('AbstractEntityEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/module.spec.ts
+++ b/packages/swagger/test/unit/specification/module.spec.ts
@@ -22,7 +22,7 @@ describe('generating swagger spec from metadata', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/module.spec.ts
+++ b/packages/swagger/test/unit/specification/module.spec.ts
@@ -14,7 +14,7 @@ import {
 import { CollectionFormat } from '@trapi/core';
 import type { Metadata } from '@trapi/core';
 import jsonata from 'jsonata';
-import { load } from 'locter';
+import { read } from 'locter';
 import type { SpecV2, SpecV3 } from '../../../src';
 import { Version, generateSwagger } from '../../../src';
 
@@ -22,7 +22,7 @@ describe('generating swagger spec from metadata', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/parameterized-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/parameterized-endpoint.spec.ts
@@ -11,7 +11,7 @@ import {
     expect, 
     it, 
 } from 'vitest';
-import { load } from 'locter';
+import { read } from 'locter';
 import jsonata from 'jsonata';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
@@ -21,7 +21,7 @@ describe('ParameterizedEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/parameterized-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/parameterized-endpoint.spec.ts
@@ -21,7 +21,7 @@ describe('ParameterizedEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/primitive-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/primitive-endpoint.spec.ts
@@ -11,7 +11,7 @@ import {
     expect, 
     it, 
 } from 'vitest';
-import { load } from 'locter';
+import { read } from 'locter';
 import jsonata from 'jsonata';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
@@ -21,7 +21,7 @@ describe('PrimitiveEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/primitive-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/primitive-endpoint.spec.ts
@@ -21,7 +21,7 @@ describe('PrimitiveEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/response-controller.spec.ts
+++ b/packages/swagger/test/unit/specification/response-controller.spec.ts
@@ -12,7 +12,7 @@ import {
     it, 
 } from 'vitest';
 import jsonata from 'jsonata';
-import { load } from 'locter';
+import { read } from 'locter';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
 import { Version, generateSwagger } from '../../../src';
@@ -21,7 +21,7 @@ describe('ResponseController', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/response-controller.spec.ts
+++ b/packages/swagger/test/unit/specification/response-controller.spec.ts
@@ -21,7 +21,7 @@ describe('ResponseController', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/type-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/type-endpoint.spec.ts
@@ -24,7 +24,7 @@ describe('TypeEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/type-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/type-endpoint.spec.ts
@@ -12,7 +12,7 @@ import {
     it, 
 } from 'vitest';
 import jsonata from 'jsonata';
-import { load } from 'locter';
+import { read } from 'locter';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
 import {
@@ -24,7 +24,7 @@ describe('TypeEndpoint', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/union-type-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/union-type-endpoint.spec.ts
@@ -21,7 +21,7 @@ describe('TestUnionType', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/union-type-endpoint.spec.ts
+++ b/packages/swagger/test/unit/specification/union-type-endpoint.spec.ts
@@ -12,7 +12,7 @@ import {
     it, 
 } from 'vitest';
 import jsonata from 'jsonata';
-import { load } from 'locter';
+import { read } from 'locter';
 import type { Metadata } from '@trapi/core';
 import type { SpecV2, SpecV3 } from '../../../src';
 import { Version, generateSwagger } from '../../../src';
@@ -21,7 +21,7 @@ describe('TestUnionType', () => {
     let spec : SpecV2 | SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V2,

--- a/packages/swagger/test/unit/specification/v3.spec.ts
+++ b/packages/swagger/test/unit/specification/v3.spec.ts
@@ -11,7 +11,7 @@ import {
     expect, 
     it, 
 } from 'vitest';
-import { load } from 'locter';
+import { read } from 'locter';
 import type { Metadata } from '@trapi/core';
 import type { SpecV3 } from '../../../src';
 import {
@@ -23,7 +23,7 @@ describe('SpecGenerator', () => {
     let spec : SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = await load('./test/data/metadata.json');
+        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
 
         spec = await generateSwagger({
             version: Version.V3,

--- a/packages/swagger/test/unit/specification/v3.spec.ts
+++ b/packages/swagger/test/unit/specification/v3.spec.ts
@@ -23,7 +23,7 @@ describe('SpecGenerator', () => {
     let spec : SpecV3;
 
     beforeAll(async () => {
-        const metadata : Metadata = (await read('./test/data/metadata.json')).default;
+        const metadata : Metadata = await read('./test/data/metadata.json');
 
         spec = await generateSwagger({
             version: Version.V3,


### PR DESCRIPTION
Migrates the four locter consumers (`cli`, `core`, `metadata`, `swagger`) to `locter@4.0.0-beta.0` ([release notes](https://github.com/tada5hi/locter/releases/tag/v4.0.0-beta.0)).

- `load` → `read` in the cli config loader, preset resolution (core + metadata), the tsconfig adapter, and the swagger specification tests.
- `read()` now returns a **frozen module record**: the tsconfig adapter unwraps `.default` (it reassigns `compilerOptions`, which would throw on the frozen record), and the swagger specs unwrap `.default` to feed plain parsed JSON into `generateSwagger`. The cli's existing `unwrapDefault` and the preset candidate chain (`.preset` → `.default` → module) already handle records.
- `isObject` / `hasOwnProperty` are no longer exported by locter 4.x — switched to `smob` (same semantics, verified; already a dependency of the swagger package, now added to cli/core/metadata).

Validation: full `nx` build (7 projects) and all test targets green against the published beta; the migrated files lint clean. (Repo-wide `npm run lint` currently trips over a stale `.claude/worktrees/typescript-v7-migration` directory with broken node_modules — pre-existing local state, unrelated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated configuration and module loading to support the latest loading behavior.
  * Improved compatibility when reading configuration, metadata, TypeScript settings, and preset modules.
  * Updated Swagger-related fixture loading while preserving existing generation behavior.
* **Bug Fixes**
  * Improved handling of object and metadata checks through updated utility support.
* **Tests**
  * Updated test setup to use the revised file-reading behavior without changing existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->