### PR TITLE
chore(release): graduate presets to stable; drop stale 2.0.0 overrides

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,12 +6,12 @@
     "bump-patch-for-minor-pre-major": true,
     "packages": {
         "packages/cli": { "component": "cli" },
-        "packages/core": { "component": "core", "release-as": "2.0.0" },
+        "packages/core": { "component": "core" },
         "packages/docs": { "component": "docs" },
-        "packages/metadata": { "component": "metadata", "release-as": "2.0.0" },
-        "packages/preset-decorators-express": { "component": "preset-decorators-express" },
-        "packages/preset-typescript-rest": { "component": "preset-typescript-rest" },
-        "packages/swagger": { "component": "swagger", "release-as": "2.0.0" }
+        "packages/metadata": { "component": "metadata" },
+        "packages/preset-decorators-express": { "component": "preset-decorators-express", "release-as": "0.2.4" },
+        "packages/preset-typescript-rest": { "component": "preset-typescript-rest", "release-as": "2.0.4" },
+        "packages/swagger": { "component": "swagger" }
     },
     "plugins": [
         {


### PR DESCRIPTION
## Why

The release PR (#864) keeps proposing beta versions for the preset packages (`0.2.4-beta.3`, `2.0.4-beta.3`). Release-please never graduates a prerelease line on its own — since the last released versions in the manifest are `0.2.3-beta.3` / `2.0.3-beta.3`, every bump just carries the `-beta.3` suffix forward.

## What

- Add a **one-time** `release-as` override so the next release graduates the presets to stable:
  - `@trapi/preset-decorators-express` → **0.2.4**
  - `@trapi/preset-typescript-rest` → **2.0.4**
- Remove the stale `release-as: "2.0.0"` overrides on core/metadata/swagger. Per 2143140 they were meant to be dropped right after the 2.0.0 graduation but never were (the linked-versions group has been bumping past them anyway).

## Follow-up

After the regenerated release PR is merged and `0.2.4` / `2.0.4` are published, the two new `release-as` entries must be removed again — otherwise every future release is pinned to those versions.